### PR TITLE
Add privileged scc to pipeline serviceaccount

### DIFF
--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -116,6 +116,15 @@ func Bootstrap(o *BootstrapParameters) error {
 	route := routes.Generate(namespaces["cicd"])
 	outputs = append(outputs, route)
 
+	// Create scc for using privileged container in Buildah task
+	scc, err := newSCC()
+	if err != nil {
+		return err
+	}
+	if err = scc.addSCCToUser("privileged", namespaces["cicd"], saName); err != nil {
+		return err
+	}
+
 	// Create secret, role binding, namespaces for using image repo
 	sa := createServiceAccount(meta.NamespacedName(namespaces["cicd"], saName))
 	manifests, err := createManifestsForImageRepo(sa, isInternalRegistry, imageRepo, o, namespaces)


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:

Added privileged SCC to the pipeline service account. 
Buildah requires privileged access to run the containers in privileged mode.

https://github.com/rhd-gitops-example/deployment-pipelines/blob/9a394126dbe4675df3c714706cdbc9addebc792e/bootstrap.sh#L58
