### PR TITLE
Generate the triggers for CI/CD environment separately

### DIFF
--- a/pkg/pipelines/tekton_builder_test.go
+++ b/pkg/pipelines/tekton_builder_test.go
@@ -186,17 +186,17 @@ func TestGetPipelines(t *testing.T) {
 
 func fakeTriggers(t *testing.T, m *config.Manifest, gitOpsRepo string) []triggersv1.EventListenerTrigger {
 	triggers := []triggersv1.EventListenerTrigger{}
+	cfg := m.GetPipelinesConfig()
+	cicdTriggers, err := createTriggersForCICD(gitOpsRepo, cfg)
+	assertNoError(t, err)
+	triggers = append(triggers, cicdTriggers...)
 	for _, env := range m.Environments {
-		cfg := m.GetPipelinesConfig()
 		svc := testService()
 		repo, err := scm.NewRepository(svc.SourceURL)
 		assertNoError(t, err)
 		pipelines := getPipelines(env, svc, repo)
 		devCITrigger := repo.CreateCITrigger(fmt.Sprintf("app-ci-build-from-pr-%s", svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, pipelines.Integration.Template, pipelines.Integration.Bindings)
 		triggers = append(triggers, devCITrigger)
-		cicdTriggers, err := createTriggersForCICD(gitOpsRepo, cfg)
-		assertNoError(t, err)
-		triggers = append(triggers, cicdTriggers...)
 	}
 
 	return triggers


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:
Currently, we generate the CI/CD triggers in the `Environment()` builder function. This results in the duplication of the CI/CD triggers since it is executed for every environment. This PR will move the code for generating CI/CD triggers outside the builder function and hence generating the triggers for CI/CD only once.
