### PR TITLE
Add support for linking apps to environments and the reverse.

### DIFF
--- a/pkg/pipelines/build.go
+++ b/pkg/pipelines/build.go
@@ -2,6 +2,7 @@ package pipelines
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/openshift/odo/pkg/pipelines/argocd"
 	"github.com/openshift/odo/pkg/pipelines/config"
@@ -37,7 +38,16 @@ func BuildResources(o *BuildParameters, appFs afero.Fs) error {
 
 func buildResources(fs afero.Fs, o *BuildParameters, m *config.Manifest) (res.Resources, error) {
 	resources := res.Resources{}
-	envs, err := environments.Build(fs, m, saName)
+
+	argoCD := m.GetArgoCDConfig()
+	log.Printf("KEVIN!!!! %#v\n", argoCD)
+	appLinks := environments.EnvironmentsToApps
+	if argoCD != nil {
+		log.Println("switching to AppsToEnvironments")
+		appLinks = environments.AppsToEnvironments
+	}
+
+	envs, err := environments.Build(fs, m, saName, appLinks)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pipelines/config/config.go
+++ b/pkg/pipelines/config/config.go
@@ -99,7 +99,6 @@ func (m *Manifest) GetArgoCDConfig() *ArgoCDConfig {
 		return m.Config.ArgoCD
 	}
 	return nil
-
 }
 
 // Environment is a slice of Apps, these are the named apps in the namespace.

--- a/pkg/pipelines/config/validate.go
+++ b/pkg/pipelines/config/validate.go
@@ -34,7 +34,6 @@ func (m *Manifest) Validate() error {
 	if err != nil {
 		vv.errs = append(vv.errs, err)
 	}
-
 	vv.errs = append(vv.errs, vv.validateServiceURLs(m.GitOpsURL)...)
 
 	if len(vv.errs) == 0 {

--- a/pkg/pipelines/environments/environments.go
+++ b/pkg/pipelines/environments/environments.go
@@ -16,6 +16,16 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 )
 
+// AppLinks represents whether or not apps are linked to environments.
+type AppLinks int
+
+const (
+	// AppsToEnvironments indicates that apps should be linked to Environments.
+	AppsToEnvironments AppLinks = iota
+	// EnvironmentsToApps indicates that environments should be linked to Apps.
+	EnvironmentsToApps
+)
+
 const kustomization = "kustomization.yaml"
 
 type envBuilder struct {
@@ -23,18 +33,21 @@ type envBuilder struct {
 	pipelinesConfig *config.PipelinesConfig
 	fs              afero.Fs
 	saName          string
+	appLinks        AppLinks
 }
 
-func Build(fs afero.Fs, m *config.Manifest, saName string) (res.Resources, error) {
+// Build generates a set of resources from the manifest, related to the
+// environment and apps and services.
+func Build(fs afero.Fs, m *config.Manifest, saName string, o AppLinks) (res.Resources, error) {
 	files := res.Resources{}
 	cfg := m.GetPipelinesConfig()
-	eb := &envBuilder{fs: fs, files: files, pipelinesConfig: cfg, saName: saName}
+	eb := &envBuilder{fs: fs, files: files, pipelinesConfig: cfg, saName: saName, appLinks: o}
 	return eb.files, m.Walk(eb)
 }
 
 func (b *envBuilder) Application(env *config.Environment, app *config.Application) error {
 	appPath := filepath.Join(config.PathForApplication(env, app))
-	appFiles, err := filesForApplication(env, appPath, app)
+	appFiles, err := filesForApplication(env, appPath, app, b.appLinks)
 	if err != nil {
 		return err
 	}
@@ -43,7 +56,6 @@ func (b *envBuilder) Application(env *config.Environment, app *config.Applicatio
 }
 
 func (b *envBuilder) Service(env *config.Environment, svc *config.Service) error {
-
 	svcPath := config.PathForService(env, svc.Name)
 	svcFiles, err := filesForService(svcPath, svc)
 	if err != nil {
@@ -75,11 +87,19 @@ func (b *envBuilder) Environment(env *config.Environment) error {
 	if _, ok := b.files[envBindingPath]; ok {
 		envFiles[envBindingPath] = b.files[envBindingPath]
 	}
-
 	for k := range envFiles {
 		kustomizedFilenames[filepath.Base(k)] = true
 	}
-	envFiles[filepath.Join(basePath, kustomization)] = &res.Kustomization{Resources: ExtractFilenames(kustomizedFilenames)}
+
+	kustomizationPath := filepath.Join(basePath, kustomization)
+	relApps, err := appsFromEnvironment(env, kustomizationPath, b.appLinks)
+	if err != nil {
+		return err
+	}
+	envFiles[kustomizationPath] = &res.Kustomization{
+		Bases:     relApps,
+		Resources: kustomizedFilenames.Items(),
+	}
 	overlaysPath := filepath.Join(envPath, "overlays")
 	relPath, err := filepath.Rel(overlaysPath, basePath)
 	if err != nil {
@@ -97,7 +117,9 @@ func filesForEnvironment(basePath string, env *config.Environment) res.Resources
 	return envFiles
 }
 
-func filesForApplication(env *config.Environment, appPath string, app *config.Application) (res.Resources, error) {
+func filesForApplication(env *config.Environment, appPath string, app *config.Application, o AppLinks) (res.Resources, error) {
+	envPath := filepath.Join(config.PathForEnvironment(env), "env")
+	envBasePath := filepath.Join(envPath, "base")
 	envFiles := res.Resources{}
 	basePath := filepath.Join(appPath, "base")
 	overlaysPath := filepath.Join(appPath, "overlays")
@@ -115,6 +137,14 @@ func filesForApplication(env *config.Environment, appPath string, app *config.Ap
 			return nil, err
 		}
 		relServices = append(relServices, relService)
+	}
+
+	if o == AppsToEnvironments {
+		relEnv, err := filepath.Rel(filepath.Dir(baseKustomization), envBasePath)
+		if err != nil {
+			return nil, err
+		}
+		relServices = append(relServices, relEnv)
 	}
 
 	envFiles[filepath.Join(appPath, kustomization)] = &res.Kustomization{Bases: []string{"overlays"}}
@@ -145,16 +175,21 @@ func filesForService(svcPath string, app *config.Service) (res.Resources, error)
 	return envFiles, nil
 }
 
-func ExtractFilenames(f map[string]bool) []string {
+// StringSet is a set of strings.
+type StringSet map[string]bool
+
+// Items returns a slice of the elements in the set.
+func (s StringSet) Items() []string {
 	names := []string{}
-	for k := range f {
+	for k := range s {
 		names = append(names, k)
 	}
 	sort.Strings(names)
 	return names
 }
 
-func ListFiles(fs afero.Fs, base string) (map[string]bool, error) {
+// ListFiles returns a set of filenames.
+func ListFiles(fs afero.Fs, base string) (StringSet, error) {
 	files := map[string]bool{}
 	err := afero.Walk(fs, base, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -174,4 +209,20 @@ func ListFiles(fs afero.Fs, base string) (map[string]bool, error) {
 		return nil
 	})
 	return files, err
+}
+
+func appsFromEnvironment(env *config.Environment, kustomizationPath string, appLinks AppLinks) ([]string, error) {
+	relApps := []string{}
+	if appLinks != EnvironmentsToApps {
+		return nil, nil
+	}
+	for _, v := range env.Apps {
+		appPath := config.PathForApplication(env, v)
+		relApp, err := filepath.Rel(filepath.Dir(kustomizationPath), appPath)
+		if err != nil {
+			return nil, err
+		}
+		relApps = append(relApps, filepath.Join(relApp, "overlays"))
+	}
+	return relApps, nil
 }

--- a/pkg/pipelines/environments/environments_test.go
+++ b/pkg/pipelines/environments/environments_test.go
@@ -1,6 +1,7 @@
 package environments
 
 import (
+	"os"
 	"sort"
 	"testing"
 
@@ -12,11 +13,43 @@ import (
 	"github.com/spf13/afero"
 )
 
-func TestBuildEnvironmentFiles(t *testing.T) {
+func TestBuildEnvironmentFilesWithAppsToEnvironment(t *testing.T) {
 	var appFs = ioutils.NewMapFilesystem()
 	m := buildManifest(true)
 
-	files, err := Build(appFs, m, "pipelines")
+	files, err := Build(appFs, m, "pipelines", AppsToEnvironments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := res.Resources{
+		"environments/test-dev/apps/my-app-1/base/kustomization.yaml": &res.Kustomization{Bases: []string{
+			"../../../services/service-http",
+			"../../../services/service-metrics",
+			"../../../env/base"}},
+		"environments/test-dev/apps/my-app-1/kustomization.yaml":                     &res.Kustomization{Bases: []string{"overlays"}},
+		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml":            &res.Kustomization{Bases: []string{"../base"}},
+		"environments/test-dev/env/base/test-dev-environment.yaml":                   namespaces.Create("test-dev"),
+		"environments/test-dev/env/base/test-dev-rolebinding.yaml":                   createRoleBinding(m.Environments[0], "environments/test-dev/env/base", "cicd", "pipelines"),
+		"environments/test-dev/env/base/kustomization.yaml":                          &res.Kustomization{Resources: []string{"test-dev-environment.yaml", "test-dev-rolebinding.yaml"}},
+		"environments/test-dev/env/overlays/kustomization.yaml":                      &res.Kustomization{Bases: []string{"../base"}},
+		"environments/test-dev/services/service-http/kustomization.yaml":             &res.Kustomization{Bases: []string{"overlays"}},
+		"environments/test-dev/services/service-http/base/kustomization.yaml":        &res.Kustomization{Bases: []string{"./config"}},
+		"environments/test-dev/services/service-http/overlays/kustomization.yaml":    &res.Kustomization{Bases: []string{"../base"}},
+		"environments/test-dev/services/service-metrics/kustomization.yaml":          &res.Kustomization{Bases: []string{"overlays"}},
+		"environments/test-dev/services/service-metrics/base/kustomization.yaml":     &res.Kustomization{Bases: []string{"./config"}},
+		"environments/test-dev/services/service-metrics/overlays/kustomization.yaml": &res.Kustomization{Bases: []string{"../base"}},
+	}
+
+	if diff := cmp.Diff(want, files); diff != "" {
+		t.Fatalf("files didn't match: %s\n", diff)
+	}
+}
+
+func TestBuildEnvironmentFilesWithEnvironmentsToApps(t *testing.T) {
+	var appFs = ioutils.NewMapFilesystem()
+	m := buildManifest(true)
+
+	files, err := Build(appFs, m, "pipelines", EnvironmentsToApps)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,11 +57,14 @@ func TestBuildEnvironmentFiles(t *testing.T) {
 		"environments/test-dev/apps/my-app-1/base/kustomization.yaml": &res.Kustomization{Bases: []string{
 			"../../../services/service-http",
 			"../../../services/service-metrics"}},
-		"environments/test-dev/apps/my-app-1/kustomization.yaml":                     &res.Kustomization{Bases: []string{"overlays"}},
-		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml":            &res.Kustomization{Bases: []string{"../base"}},
-		"environments/test-dev/env/base/test-dev-environment.yaml":                   namespaces.Create("test-dev"),
-		"environments/test-dev/env/base/test-dev-rolebinding.yaml":                   createRoleBinding(m.Environments[0], "environments/test-dev/env/base", "cicd", "pipelines"),
-		"environments/test-dev/env/base/kustomization.yaml":                          &res.Kustomization{Resources: []string{"test-dev-environment.yaml", "test-dev-rolebinding.yaml"}},
+		"environments/test-dev/apps/my-app-1/kustomization.yaml":          &res.Kustomization{Bases: []string{"overlays"}},
+		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml": &res.Kustomization{Bases: []string{"../base"}},
+		"environments/test-dev/env/base/test-dev-environment.yaml":        namespaces.Create("test-dev"),
+		"environments/test-dev/env/base/test-dev-rolebinding.yaml":        createRoleBinding(m.Environments[0], "environments/test-dev/env/base", "cicd", "pipelines"),
+		"environments/test-dev/env/base/kustomization.yaml": &res.Kustomization{
+			Resources: []string{"test-dev-environment.yaml", "test-dev-rolebinding.yaml"},
+			Bases:     []string{"../../apps/my-app-1/overlays"},
+		},
 		"environments/test-dev/env/overlays/kustomization.yaml":                      &res.Kustomization{Bases: []string{"../base"}},
 		"environments/test-dev/services/service-http/kustomization.yaml":             &res.Kustomization{Bases: []string{"overlays"}},
 		"environments/test-dev/services/service-http/base/kustomization.yaml":        &res.Kustomization{Bases: []string{"./config"}},
@@ -56,7 +92,7 @@ func TestBuildEnvironmentsDoesNotOutputCIorArgo(t *testing.T) {
 		},
 	}
 
-	files, err := Build(appFs, m, "pipelines")
+	files, err := Build(appFs, m, "pipelines", AppsToEnvironments)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,12 +103,23 @@ func TestBuildEnvironmentsDoesNotOutputCIorArgo(t *testing.T) {
 	}
 }
 
+func mustWriteFile(t *testing.T, fs afero.Fs, path string, data []byte, perm os.FileMode) {
+	t.Helper()
+	err := afero.WriteFile(fs, path, data, perm)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestBuildEnvironmentsAddsKustomizedFiles(t *testing.T) {
 	var appFs = ioutils.NewMapFilesystem()
-	_ = appFs.MkdirAll("environments/test-dev/base", 0755)
-	_ = afero.WriteFile(appFs, "environments/test-dev/base/volume.yaml", []byte(`this is a file`), 0644)
-	_ = afero.WriteFile(appFs, "environments/test-dev/base/test-dev-environment.yaml", []byte(`this is a file`), 0644)
-	_ = afero.WriteFile(appFs, "environments/test-dev/base/routes/01-route.yaml", []byte(`this is a file`), 0644)
+	err := appFs.MkdirAll("environments/test-dev/base", 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, appFs, "environments/test-dev/base/volume.yaml", []byte(`this is a file`), 0644)
+	mustWriteFile(t, appFs, "environments/test-dev/base/test-dev-environment.yaml", []byte(`this is a file`), 0644)
+	mustWriteFile(t, appFs, "environments/test-dev/base/routes/01-route.yaml", []byte(`this is a file`), 0644)
 
 	m := &config.Manifest{
 		Config: &config.Config{
@@ -85,7 +132,7 @@ func TestBuildEnvironmentsAddsKustomizedFiles(t *testing.T) {
 		},
 	}
 
-	resources, err := Build(appFs, m, "pipelines")
+	resources, err := Build(appFs, m, "pipelines", EnvironmentsToApps)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +153,7 @@ func TestBuildEnvironmentFilesWithNoCICDEnv(t *testing.T) {
 	var appFs = ioutils.NewMapFilesystem()
 	m := buildManifest(false)
 
-	files, err := Build(appFs, m, "pipelines")
+	files, err := Build(appFs, m, "pipelines", AppsToEnvironments)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +161,8 @@ func TestBuildEnvironmentFilesWithNoCICDEnv(t *testing.T) {
 	want := res.Resources{
 		"environments/test-dev/apps/my-app-1/base/kustomization.yaml": &res.Kustomization{Bases: []string{
 			"../../../services/service-http",
-			"../../../services/service-metrics"}},
+			"../../../services/service-metrics",
+			"../../../env/base"}},
 		"environments/test-dev/apps/my-app-1/kustomization.yaml":                     &res.Kustomization{Bases: []string{"overlays"}},
 		"environments/test-dev/apps/my-app-1/overlays/kustomization.yaml":            &res.Kustomization{Bases: []string{"../base"}},
 		"environments/test-dev/env/base/test-dev-environment.yaml":                   namespaces.Create("test-dev"),

--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -171,11 +171,11 @@ func createService(serviceName, url string) (*config.Service, error) {
 
 func updateKustomization(fs afero.Fs, base string) error {
 	files := res.Resources{}
-	list, err := environments.ListFiles(fs, base)
+	filenames, err := environments.ListFiles(fs, base)
 	if err != nil {
 		return err
 	}
-	files[Kustomize] = &res.Kustomization{Resources: environments.ExtractFilenames(list)}
+	files[Kustomize] = &res.Kustomization{Resources: filenames.Items()}
 	_, err = yaml.WriteResources(fs, base, files)
 	return err
 }


### PR DESCRIPTION
This adds support for determining whether or not an environment is linked to
its constituent apps, or linking apps to their environments.

The former is necessary to be able to bring up all the apps in an environment,
and the latter is necessary to bring up apps with their dependencies in the
environment.

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
/kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
