### PR TITLE
Add tag to the image built by the application CI pipeline

### DIFF
--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -83,7 +83,7 @@ func createDevResource(revision string) []pipelinev1.PipelineResourceBinding {
 			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
 				Type: "image",
 				Params: []pipelinev1.ResourceParam{
-					createResourceParams("url", "$(params.imageRepo)"),
+					createResourceParams("url", "$(params.imageRepo):$(params.gitref)-$(params.gitsha)"),
 				},
 			},
 		},

--- a/pkg/pipelines/triggers/pipelinerun_test.go
+++ b/pkg/pipelines/triggers/pipelinerun_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
 	"github.com/openshift/odo/pkg/pipelines/meta"
@@ -80,5 +81,33 @@ func TestCreateStageCIPipelineRun(t *testing.T) {
 	template := createCIPipelineRun(sName)
 	if diff := cmp.Diff(validStageCIPipeline, template); diff != "" {
 		t.Fatalf("createCIPipelineRun failed:\n%s", diff)
+	}
+}
+
+func TestCreateDevResource(t *testing.T) {
+	want := []pipelinev1.PipelineResourceBinding{
+		{
+			Name: "source-repo",
+			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
+				Type: "git",
+				Params: []pipelinev1.ResourceParam{
+					createResourceParams("revision", "test"),
+					createResourceParams("url", "$(params.gitrepositoryurl)"),
+				},
+			},
+		},
+		{
+			Name: "runtime-image",
+			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
+				Type: "image",
+				Params: []pipelinev1.ResourceParam{
+					createResourceParams("url", "$(params.imageRepo):$(params.gitref)-$(params.gitsha)"),
+				},
+			},
+		},
+	}
+	got := createDevResource("test")
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("createDevResource() failed: \n%s", diff)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:

We need tags to differentiate the version of the application deployed. The earlier version of the pipeline added tags.This PR adds a tag for the image built by the application pipeline.
