### PR TITLE
Add the standard Kubernetes labels to the bootstrapped nginx Deployment

### DIFF
--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -102,7 +102,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	if devEnv == nil {
 		return nil, errors.New("unable to bootstrap without dev environment")
 	}
-	svcFiles, err := bootstrapServiceDeployment(devEnv)
+	svcFiles, err := bootstrapServiceDeployment(devEnv, repoName)
 	if err != nil {
 		return nil, err
 	}
@@ -154,13 +154,13 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	return bootstrapped, nil
 }
 
-func bootstrapServiceDeployment(dev *config.Environment) (res.Resources, error) {
+func bootstrapServiceDeployment(dev *config.Environment, appName string) (res.Resources, error) {
 	svc := dev.Services[0]
 	svcBase := filepath.Join(config.PathForService(dev, svc.Name), "base", "config")
 	resources := res.Resources{}
 	// TODO: This should change if we add Namespace to Environment.
 	// We'd need to create the resources in the namespace _of_ the Environment.
-	resources[filepath.Join(svcBase, "100-deployment.yaml")] = deployment.Create(dev.Name, svc.Name, bootstrapImage, deployment.ContainerPort(8080))
+	resources[filepath.Join(svcBase, "100-deployment.yaml")] = deployment.Create(appName, dev.Name, svc.Name, bootstrapImage, deployment.ContainerPort(8080))
 	resources[filepath.Join(svcBase, "200-service.yaml")] = createBootstrapService(dev.Name, svc.Name)
 	resources[filepath.Join(svcBase, "kustomization.yaml")] = &res.Kustomization{Resources: []string{"100-deployment.yaml", "200-service.yaml"}}
 	return resources, nil

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -161,7 +161,7 @@ func bootstrapServiceDeployment(dev *config.Environment, appName string) (res.Re
 	// TODO: This should change if we add Namespace to Environment.
 	// We'd need to create the resources in the namespace _of_ the Environment.
 	resources[filepath.Join(svcBase, "100-deployment.yaml")] = deployment.Create(appName, dev.Name, svc.Name, bootstrapImage, deployment.ContainerPort(8080))
-	resources[filepath.Join(svcBase, "200-service.yaml")] = createBootstrapService(dev.Name, svc.Name)
+	resources[filepath.Join(svcBase, "200-service.yaml")] = createBootstrapService(appName, dev.Name, svc.Name)
 	resources[filepath.Join(svcBase, "kustomization.yaml")] = &res.Kustomization{Resources: []string{"100-deployment.yaml", "200-service.yaml"}}
 	return resources, nil
 }
@@ -241,7 +241,7 @@ func orgRepoFromURL(raw string) (string, error) {
 	return strings.TrimSuffix(orgRepo, ".git"), nil
 }
 
-func createBootstrapService(ns, name string) *corev1.Service {
+func createBootstrapService(appName, ns, name string) *corev1.Service {
 	svc := &corev1.Service{
 		TypeMeta:   meta.TypeMeta("Service", "v1"),
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, name)),
@@ -257,6 +257,7 @@ func createBootstrapService(ns, name string) *corev1.Service {
 	}
 	labels := map[string]string{
 		deployment.KubernetesAppNameLabel: name,
+		deployment.KubernetesPartOfLabel:  appName,
 	}
 	svc.ObjectMeta.Labels = labels
 	svc.Spec.Selector = labels

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -53,7 +53,7 @@ func TestBootstrapManifest(t *testing.T) {
 	}
 	want := res.Resources{
 		"config/tst-cicd/base/pipelines/03-secrets/webhook-secret-tst-dev-http-api-svc.yaml": hookSecret,
-		"environments/tst-dev/services/http-api-svc/base/config/100-deployment.yaml":         deployment.Create("tst-dev", "http-api-svc", bootstrapImage, deployment.ContainerPort(8080)),
+		"environments/tst-dev/services/http-api-svc/base/config/100-deployment.yaml":         deployment.Create("taxi", "tst-dev", "http-api-svc", bootstrapImage, deployment.ContainerPort(8080)),
 		"environments/tst-dev/services/http-api-svc/base/config/200-service.yaml":            createBootstrapService("tst-dev", "http-api-svc"),
 		"environments/tst-dev/services/http-api-svc/base/config/kustomization.yaml":          &res.Kustomization{Resources: []string{"100-deployment.yaml", "200-service.yaml"}},
 		pipelinesFile: &config.Manifest{

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -54,7 +54,7 @@ func TestBootstrapManifest(t *testing.T) {
 	want := res.Resources{
 		"config/tst-cicd/base/pipelines/03-secrets/webhook-secret-tst-dev-http-api-svc.yaml": hookSecret,
 		"environments/tst-dev/services/http-api-svc/base/config/100-deployment.yaml":         deployment.Create("taxi", "tst-dev", "http-api-svc", bootstrapImage, deployment.ContainerPort(8080)),
-		"environments/tst-dev/services/http-api-svc/base/config/200-service.yaml":            createBootstrapService("tst-dev", "http-api-svc"),
+		"environments/tst-dev/services/http-api-svc/base/config/200-service.yaml":            createBootstrapService("taxi", "tst-dev", "http-api-svc"),
 		"environments/tst-dev/services/http-api-svc/base/config/kustomization.yaml":          &res.Kustomization{Resources: []string{"100-deployment.yaml", "200-service.yaml"}},
 		pipelinesFile: &config.Manifest{
 			GitOpsURL: "https://github.com/my-org/gitops.git",

--- a/pkg/pipelines/deployment/deployment.go
+++ b/pkg/pipelines/deployment/deployment.go
@@ -14,6 +14,9 @@ const KubernetesAppNameLabel = "app.kubernetes.io/name"
 // KubernetesAppVersionLabel string constant for Kubernetes App Version label
 const KubernetesAppVersionLabel = "app.kubernetes.io/version"
 
+// KubernetesPartOfLabel string constant for Kubernetes App PartOf label
+const KubernetesPartOfLabel = "app.kubernetes.io/part-of"
+
 // ServiceAccount is an option that configures the deployment's pods to execute
 // with the provided service account name.
 func ServiceAccount(sa string) podSpecFunc {
@@ -47,21 +50,21 @@ func ContainerPort(p int32) podSpecFunc {
 }
 
 // Create creates and returns a Deployment with the specified configuration.
-func Create(ns, name, image string, opts ...podSpecFunc) *appsv1.Deployment {
+func Create(partOfLabel, ns, name, image string, opts ...podSpecFunc) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta:   meta.TypeMeta("Deployment", "apps/v1"),
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, name)),
 		Spec: appsv1.DeploymentSpec{
 			Replicas: ptr32(1),
-			Selector: labelSelector(KubernetesAppNameLabel, name),
-			Template: podTemplate(name, image, opts...),
+			Selector: LabelSelector(name, partOfLabel),
+			Template: podTemplate(partOfLabel, name, image, opts...),
 		},
 	}
 }
 
 type podSpecFunc func(t *corev1.PodSpec)
 
-func podTemplate(name, image string, opts ...podSpecFunc) corev1.PodTemplateSpec {
+func podTemplate(partOfLabel, name, image string, opts ...podSpecFunc) corev1.PodTemplateSpec {
 	podSpec := &corev1.PodSpec{
 		ServiceAccountName: "default",
 		Containers: []corev1.Container{
@@ -81,6 +84,7 @@ func podTemplate(name, image string, opts ...podSpecFunc) corev1.PodTemplateSpec
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				KubernetesAppNameLabel: name,
+				KubernetesPartOfLabel:  partOfLabel,
 			},
 		},
 		Spec: *podSpec,
@@ -91,10 +95,12 @@ func ptr32(i int32) *int32 {
 	return &i
 }
 
-func labelSelector(name, value string) *metav1.LabelSelector {
+//LabelSelector used to create the labelSelector for the commit status tracker
+func LabelSelector(name, partOf string) *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			name: value,
+			KubernetesAppNameLabel: name,
+			KubernetesPartOfLabel:  partOf,
 		},
 	}
 }

--- a/pkg/pipelines/deployment/deployment.go
+++ b/pkg/pipelines/deployment/deployment.go
@@ -50,14 +50,14 @@ func ContainerPort(p int32) podSpecFunc {
 }
 
 // Create creates and returns a Deployment with the specified configuration.
-func Create(partOfLabel, ns, name, image string, opts ...podSpecFunc) *appsv1.Deployment {
+func Create(partOf, ns, name, image string, opts ...podSpecFunc) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta:   meta.TypeMeta("Deployment", "apps/v1"),
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, name)),
 		Spec: appsv1.DeploymentSpec{
 			Replicas: ptr32(1),
-			Selector: LabelSelector(name, partOfLabel),
-			Template: podTemplate(partOfLabel, name, image, opts...),
+			Selector: LabelSelector(name, partOf),
+			Template: podTemplate(partOf, name, image, opts...),
 		},
 	}
 }

--- a/pkg/pipelines/statustracker/deployment.go
+++ b/pkg/pipelines/statustracker/deployment.go
@@ -7,7 +7,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openshift/odo/pkg/pipelines/deployment"
@@ -17,8 +16,9 @@ import (
 )
 
 const (
-	operatorName   = "commit-status-tracker"
-	containerImage = "quay.io/redhat-developer/commit-status-tracker:v0.0.1"
+	operatorName         = "commit-status-tracker"
+	containerImage       = "quay.io/redhat-developer/commit-status-tracker:v0.0.1"
+	commitStatusAppLabel = "commit-status-tracker-operator"
 )
 
 type secretSealer = func(types.NamespacedName, string, string) (*ssv1alpha1.SealedSecret, error)
@@ -90,7 +90,7 @@ var (
 )
 
 func createStatusTrackerDeployment(ns string) *appsv1.Deployment {
-	return deployment.Create(ns, operatorName, containerImage,
+	return deployment.Create(commitStatusAppLabel, ns, operatorName, containerImage,
 		deployment.ServiceAccount(operatorName),
 		deployment.Env(statusTrackerEnv),
 		deployment.Command([]string{operatorName}))
@@ -130,12 +130,4 @@ func Resources(ns, token string) ([]interface{}, error) {
 
 func ptr32(i int32) *int32 {
 	return &i
-}
-
-func labelSelector(name, value string) *metav1.LabelSelector {
-	return &metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			name: value,
-		},
-	}
 }

--- a/pkg/pipelines/statustracker/deployment_test.go
+++ b/pkg/pipelines/statustracker/deployment_test.go
@@ -23,11 +23,12 @@ func TestCreateStatusTrackerDeployment(t *testing.T) {
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("dana-cicd", operatorName)),
 		Spec: appsv1.DeploymentSpec{
 			Replicas: ptr32(1),
-			Selector: labelSelector(deployment.KubernetesAppNameLabel, operatorName),
+			Selector: deployment.LabelSelector(operatorName, commitStatusAppLabel),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						deployment.KubernetesAppNameLabel: operatorName,
+						deployment.KubernetesPartOfLabel:  commitStatusAppLabel,
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
**What type of PR is this?**
> kind cleanup

**What does does this PR do / why we need it**:
This PR adds kubernetes labels in accordance with the openshift web console, thus making it easier on the topology view on the UI side.

The part of label has been added to the label selector.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-165

