### PR TITLE
Restoring commit status tracker 

### DIFF
--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -59,7 +59,7 @@ func (io *BootstrapParameters) Complete(name string, cmd *cobra.Command, args []
 func (io *BootstrapParameters) Validate() error {
 	gr, err := url.Parse(io.GitOpsRepoURL)
 	if err != nil {
-		return fmt.Errorf("failed to parse url %s: %v", io.GitOpsRepoURL, err)
+		return fmt.Errorf("failed to parse url %s: %w", io.GitOpsRepoURL, err)
 	}
 
 	// TODO: this won't work with GitLab as the repo can have more path elements.
@@ -86,9 +86,9 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 
 	initCmd := &cobra.Command{
 		Use:     name,
-		Short:   bootstrapShortDesc,
-		Long:    bootstrapLongDesc,
-		Example: fmt.Sprintf(bootstrapExample, fullName),
+		Short:   initShortDesc,
+		Long:    initLongDesc,
+		Example: fmt.Sprintf(initExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},
@@ -105,6 +105,8 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	initCmd.Flags().StringVar(&o.OutputPath, "output", ".", "folder path to add Gitops resources")
 	initCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "add a prefix to the environment names")
 	initCmd.Flags().StringVarP(&o.ImageRepo, "image-repo", "", "", "used to push built images")
+
+	initCmd.Flags().StringVarP(&o.StatusTrackerAccessToken, "status-tracker-access-token", "", "", "used to authenticate requests to push commit-statuses to your Git hosting service")
 
 	initCmd.MarkFlagRequired("gitops-repo-url")
 	initCmd.MarkFlagRequired("app-repo-url")

--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -86,9 +86,9 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 
 	initCmd := &cobra.Command{
 		Use:     name,
-		Short:   initShortDesc,
-		Long:    initLongDesc,
-		Example: fmt.Sprintf(initExample, fullName),
+		Short:   bootstrapShortDesc,
+		Long:    bootstrapLongDesc,
+		Example: fmt.Sprintf(bootstrapExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			genericclioptions.GenericRun(o, cmd, args)
 		},

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -38,8 +38,8 @@ type InitParameters struct {
 	output                   string // path to add Gitops resources
 	prefix                   string // used to generate the environments in a shared cluster
 	imageRepo                string
-	internalRegistryHostname string
-	// generic context options common to all commands
+	internalRegistryHostname string // generic context options common to all commands
+	StatusTrackerAccessToken string
 	*genericclioptions.Context
 }
 
@@ -85,6 +85,7 @@ func (io *InitParameters) Run() error {
 		Prefix:                   io.prefix,
 		ImageRepo:                io.imageRepo,
 		InternalRegistryHostname: io.internalRegistryHostname,
+		StatusTrackerAccessToken: io.StatusTrackerAccessToken,
 	}
 	err := pipelines.Init(&options, ioutils.NewFilesystem())
 	if err != nil {
@@ -116,6 +117,6 @@ func NewCmdInit(name, fullName string) *cobra.Command {
 	initCmd.Flags().StringVar(&o.dockercfgjson, "dockercfgjson", "", "dockercfg json pathname")
 	initCmd.Flags().StringVar(&o.internalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	initCmd.Flags().StringVar(&o.imageRepo, "image-repo", "", "image repository in this form <registry>/<username>/<repository> or <project>/<app> for internal registry")
-
+	initCmd.Flags().StringVar(&o.StatusTrackerAccessToken, "status-tracker-access-token", "", "used to authenticate requests to push commit-statuses to your Git hosting service")
 	return initCmd
 }

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -100,7 +100,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 		return nil, fmt.Errorf("invalid app repo URL: %v", err)
 	}
 
-	bootstrapped, err := createInitialFiles(appFs, gitOpsRepo, o.Prefix, o.GitOpsWebhookSecret, o.DockerConfigJSONFilename, o.StatusTrackerAccessToken)
+	bootstrapped, err := createInitialFiles(appFs, gitOpsRepo, o.Prefix, o.GitOpsWebhookSecret, o.DockerConfigJSONFilename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -22,8 +22,8 @@ import (
 	"github.com/openshift/odo/pkg/pipelines/roles"
 	"github.com/openshift/odo/pkg/pipelines/scm"
 	"github.com/openshift/odo/pkg/pipelines/secrets"
-	"github.com/openshift/odo/pkg/pipelines/yaml"
 	"github.com/openshift/odo/pkg/pipelines/statustracker"
+	"github.com/openshift/odo/pkg/pipelines/yaml"
 )
 
 const (
@@ -100,7 +100,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 		return nil, fmt.Errorf("invalid app repo URL: %v", err)
 	}
 
-	bootstrapped, err := createInitialFiles(appFs, gitOpsRepo, o.Prefix, o.GitOpsWebhookSecret, o.DockerConfigJSONFilename)
+	bootstrapped, err := createInitialFiles(appFs, gitOpsRepo, o.Prefix, o.GitOpsWebhookSecret, o.DockerConfigJSONFilename, o.StatusTrackerAccessToken)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -35,12 +35,14 @@ func TestBootstrapManifest(t *testing.T) {
 	}
 
 	params := &BootstrapOptions{
-		Prefix:               "tst-",
-		GitOpsRepoURL:        testGitOpsRepo,
-		GitOpsWebhookSecret:  "123",
-		ServiceRepoURL:       testSvcRepo,
-		ImageRepo:            "image/repo",
-		ServiceWebhookSecret: "456",
+		Prefix:                   "tst-",
+		GitOpsRepoURL:            testGitOpsRepo,
+		GitOpsWebhookSecret:      "123",
+		ServiceRepoURL:           testSvcRepo,
+		ImageRepo:                "image/repo",
+		ServiceWebhookSecret:     "456",
+		Prefix:                   "tst-",
+		StatusTrackerAccessToken: "this-is-a-test",
 	}
 
 	r, err := bootstrapResources(params, ioutils.NewMapFilesystem())
@@ -106,11 +108,16 @@ func TestBootstrapManifest(t *testing.T) {
 		t.Fatalf("bootstrapped resources:\n%s", diff)
 	}
 
-	wantResources := []string{"01-namespaces/cicd-environment.yaml",
+	wantResources := []string{
+		"01-namespaces/cicd-environment.yaml",
 		"01-namespaces/image.yaml",
+		"02-rolebindings/commit-status-tracker-role.yaml",
+		"02-rolebindings/commit-status-tracker-rolebinding.yaml",
+		"02-rolebindings/commit-status-tracker-service-role.yaml",
 		"02-rolebindings/internal-registry-image-binding.yaml",
 		"02-rolebindings/pipeline-service-role.yaml",
 		"02-rolebindings/pipeline-service-rolebinding.yaml",
+		"03-secrets/commit-status-tracker.yaml",
 		"03-secrets/gitops-webhook-secret.yaml",
 		"03-secrets/webhook-secret-tst-dev-http-api.yaml",
 		"04-tasks/deploy-from-source-task.yaml",
@@ -126,6 +133,7 @@ func TestBootstrapManifest(t *testing.T) {
 		"07-templates/ci-dryrun-from-pr-template.yaml",
 		"08-eventlisteners/cicd-event-listener.yaml",
 		"09-routes/gitops-webhook-event-listener.yaml",
+		"10-commit-status-tracker/operator.yaml",
 	}
 	k := r["config/tst-cicd/base/pipelines/kustomization.yaml"].(res.Kustomization)
 	if diff := cmp.Diff(wantResources, k.Resources); diff != "" {

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -41,7 +41,6 @@ func TestBootstrapManifest(t *testing.T) {
 		ServiceRepoURL:           testSvcRepo,
 		ImageRepo:                "image/repo",
 		ServiceWebhookSecret:     "456",
-		Prefix:                   "tst-",
 		StatusTrackerAccessToken: "this-is-a-test",
 	}
 

--- a/pkg/pipelines/imagerepo/imagerepo.go
+++ b/pkg/pipelines/imagerepo/imagerepo.go
@@ -59,25 +59,21 @@ func imageRepoValidationErrors(imageRepo string) error {
 	return fmt.Errorf("failed to parse image repo:%s, expected image repository in the form <registry>/<username>/<repository> or <project>/<app> for internal registry", imageRepo)
 }
 
-func CreateInternalRegistryResources(cfg *config.PipelinesConfig, sa *corev1.ServiceAccount, imageRepo string) ([]string, res.Resources, error) {
+// CreateInternalRegistryResources creates the resources for accessing the
+// internal registry.
+func CreateInternalRegistryResources(cfg *config.PipelinesConfig, sa *corev1.ServiceAccount, imageRepo string) (res.Resources, error) {
 	// Provide access to service account for using internal registry
 	namespace := strings.Split(imageRepo, "/")[1]
 
 	resources := res.Resources{}
-	filenames := []string{}
-
 	filename := filepath.Join("01-namespaces", fmt.Sprintf("%s.yaml", namespace))
-	namespacePath := filepath.Join(config.PathForPipelines(cfg), "base", "pipelines", filename)
-	resources[namespacePath] = namespaces.Create(namespace)
-	filenames = append(filenames, filename)
-
-	filename, roleBinding := createInternalRegistryRoleBinding(cfg, namespace, sa)
-	return append(filenames, filename), res.Merge(roleBinding, resources), nil
+	resources[filename] = namespaces.Create(namespace)
+	roleBinding := createInternalRegistryRoleBinding(cfg, namespace, sa)
+	return res.Merge(roleBinding, resources), nil
 }
 
-func createInternalRegistryRoleBinding(cfg *config.PipelinesConfig, ns string, sa *corev1.ServiceAccount) (string, res.Resources) {
+func createInternalRegistryRoleBinding(cfg *config.PipelinesConfig, ns string, sa *corev1.ServiceAccount) res.Resources {
 	roleBindingName := fmt.Sprintf("internal-registry-%s-binding", ns)
-	roleBindingFilname := filepath.Join("02-rolebindings", fmt.Sprintf("%s.yaml", roleBindingName))
-	roleBindingPath := filepath.Join(config.PathForPipelines(cfg), "base", "pipelines", roleBindingFilname)
-	return roleBindingFilname, res.Resources{roleBindingPath: roles.CreateRoleBinding(meta.NamespacedName(ns, roleBindingName), sa, "ClusterRole", "edit")}
+	roleBindingFilename := filepath.Join("02-rolebindings", fmt.Sprintf("%s.yaml", roleBindingName))
+	return res.Resources{roleBindingFilename: roles.CreateRoleBinding(meta.NamespacedName(ns, roleBindingName), sa, "ClusterRole", "edit")}
 }

--- a/pkg/pipelines/imagerepo/imagerepo_test.go
+++ b/pkg/pipelines/imagerepo/imagerepo_test.go
@@ -17,9 +17,9 @@ func TestCreateInternalRegistryRoleBinding(t *testing.T) {
 		Name: "test-cicd",
 	}
 	sa := roles.CreateServiceAccount(meta.NamespacedName("test-cicd", "pipeline"))
-	gotFilename, got := createInternalRegistryRoleBinding(pipelinesConfig, "new-proj", sa)
+	got := createInternalRegistryRoleBinding(pipelinesConfig, "new-proj", sa)
 
-	want := res.Resources{"config/test-cicd/base/pipelines/02-rolebindings/internal-registry-new-proj-binding.yaml": &v1rbac.RoleBinding{
+	want := res.Resources{"02-rolebindings/internal-registry-new-proj-binding.yaml": &v1rbac.RoleBinding{
 		TypeMeta:   meta.TypeMeta("RoleBinding", "rbac.authorization.k8s.io/v1"),
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("new-proj", "internal-registry-new-proj-binding")),
 		Subjects:   []v1rbac.Subject{{Kind: sa.Kind, Name: sa.Name, Namespace: sa.Namespace}},
@@ -30,12 +30,8 @@ func TestCreateInternalRegistryRoleBinding(t *testing.T) {
 		},
 	}}
 
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("resources do not match:\n%s", diff)
-	}
-
-	if diff := cmp.Diff(gotFilename, "02-rolebindings/internal-registry-new-proj-binding.yaml"); diff != "" {
-		t.Errorf("filename do not match:\n%s", diff)
 	}
 }
 

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -38,6 +38,7 @@ type InitParameters struct {
 	InternalRegistryHostname string
 	OutputPath               string
 	Prefix                   string
+	StatusTrackerAccessToken string
 }
 
 // PolicyRules to be bound to service account
@@ -84,6 +85,9 @@ const (
 	rolesPath                = "02-rolebindings/pipeline-service-role.yaml"
 	rolebindingsPath         = "02-rolebindings/pipeline-service-rolebinding.yaml"
 	serviceAccountPath       = "02-rolebindings/pipeline-service-account.yaml"
+	statusTrackerRole        = "02-rolebindings/commit-status-tracker-role.yaml"
+	stustTrackerRolebinding  = "02-rolebindings/commit-status-tracker-rolebinding.yaml"
+	statustrackerserviceRole = "02-rolebindings/commit-status-tracker-service-role.yaml"
 	secretsPath              = "03-secrets/gitops-webhook-secret.yaml"
 	dockerConfigPath         = "03-secrets/docker-config.yaml"
 	gitopsTasksPath          = "04-tasks/deploy-from-source-task.yaml"

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openshift/odo/pkg/pipelines/routes"
 	"github.com/openshift/odo/pkg/pipelines/scm"
 	"github.com/openshift/odo/pkg/pipelines/secrets"
-	"github.com/openshift/odo/pkg/pipelines/statustracker"
 	"github.com/openshift/odo/pkg/pipelines/tasks"
 	"github.com/openshift/odo/pkg/pipelines/triggers"
 	"github.com/openshift/odo/pkg/pipelines/yaml"
@@ -123,7 +122,7 @@ func Init(o *InitParameters, fs afero.Fs) error {
 		return err
 	}
 
-	outputs, err := createInitialFiles(fs, gitOpsRepo, o.Prefix, o.GitOpsWebhookSecret, o.DockerConfigJSONFilename, o.StatusTrackerAccessToken)
+	outputs, err := createInitialFiles(fs, gitOpsRepo, o.Prefix, o.GitOpsWebhookSecret, o.DockerConfigJSONFilename)
 	if err != nil {
 		return err
 	}
@@ -156,14 +155,14 @@ func CreateDockerSecret(fs afero.Fs, dockerConfigJSONFilename, ns string) (*ssv1
 
 }
 
-func createInitialFiles(fs afero.Fs, repo scm.Repository, prefix, gitOpsWebhookSecret, dockerConfigPath, StatusTrackerAccessToken string) (res.Resources, error) {
+func createInitialFiles(fs afero.Fs, repo scm.Repository, prefix, gitOpsWebhookSecret, dockerConfigPath string) (res.Resources, error) {
 	cicd := &config.PipelinesConfig{Name: prefix + "cicd"}
 	pipelineConfig := &config.Config{Pipelines: cicd}
 	m := createManifest(repo.URL(), pipelineConfig)
 	initialFiles := res.Resources{
 		pipelinesFile: m,
 	}
-	resources, err := createCICDResources(fs, repo, cicd, gitOpsWebhookSecret, dockerConfigPath, StatusTrackerAccessToken)
+	resources, err := createCICDResources(fs, repo, cicd, gitOpsWebhookSecret, dockerConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +178,7 @@ func createInitialFiles(fs afero.Fs, repo scm.Repository, prefix, gitOpsWebhookS
 }
 
 // createCICDResources creates resources assocated to pipelines.
-func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *config.PipelinesConfig, gitOpsWebhookSecret, dockerConfigJSONPath, StatusTracker string) (res.Resources, error) {
+func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *config.PipelinesConfig, gitOpsWebhookSecret, dockerConfigJSONPath string) (res.Resources, error) {
 	cicdNamespace := pipelineConfig.Name
 	// key: path of the resource
 	// value: YAML content of the resource
@@ -205,15 +204,6 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 
 		// add secret and sa to outputs
 		outputs[serviceAccountPath] = roles.AddSecretToSA(sa, dockerSecretName)
-	}
-
-	if StatusTracker != "" {
-		trackerResources, err := statustracker.Resources(cicdNamespace, StatusTracker)
-		if err != nil {
-			return nil, err
-		}
-		outputs = res.Merge(outputs, trackerResources)
-
 	}
 
 	outputs[rolebindingsPath] = roles.CreateClusterRoleBinding(meta.NamespacedName("", roleBindingName), sa, "ClusterRole", roles.ClusterRoleName)

--- a/pkg/pipelines/resources/merge.go
+++ b/pkg/pipelines/resources/merge.go
@@ -1,7 +1,11 @@
 package resources
 
+// Resources is a mapping of filename to k8s resource suitable for marshaling to
+// YAML.
 type Resources map[string]interface{}
 
+// Merge accepts to sets of resources, and merges them overwriting resources in
+// the "to" set with resources from the "from" set.
 func Merge(from, to Resources) Resources {
 	merged := Resources{}
 	for k, v := range to {

--- a/pkg/pipelines/secrets/secrets.go
+++ b/pkg/pipelines/secrets/secrets.go
@@ -100,7 +100,7 @@ func getClusterPublicKey() (*rsa.PublicKey, error) {
 func openCertCluster(c clientv1.CoreV1Interface) (io.ReadCloser, error) {
 	f, err := c.
 		Services("kube-system").
-		ProxyGet("http", "sealedsecretcontroller-sealed-secrets", "", "/v1/cert.pem", nil).
+		ProxyGet("http", "sealed-secrets-controller", "", "/v1/cert.pem", nil).
 		Stream()
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch certificate: %v", err)

--- a/pkg/pipelines/statustracker/deployment.go
+++ b/pkg/pipelines/statustracker/deployment.go
@@ -4,11 +4,6 @@ import (
 	"fmt"
 
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/types"
-	res "github.com/openshift/odo/pkg/pipelines/resources"
 	"github.com/openshift/odo/pkg/pipelines/deployment"
 	"github.com/openshift/odo/pkg/pipelines/meta"
 	res "github.com/openshift/odo/pkg/pipelines/resources"

--- a/pkg/pipelines/statustracker/deployment.go
+++ b/pkg/pipelines/statustracker/deployment.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
+	res "github.com/openshift/odo/pkg/pipelines/resources"
 	"github.com/openshift/odo/pkg/pipelines/deployment"
 	"github.com/openshift/odo/pkg/pipelines/meta"
 	res "github.com/openshift/odo/pkg/pipelines/resources"

--- a/pkg/pipelines/statustracker/deployment_test.go
+++ b/pkg/pipelines/statustracker/deployment_test.go
@@ -5,16 +5,16 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/odo/pkg/pipelines/deployment"
 	"github.com/openshift/odo/pkg/pipelines/meta"
-	"github.com/openshift/odo/pkg/pipelines/roles"
 	res "github.com/openshift/odo/pkg/pipelines/resources"
+	"github.com/openshift/odo/pkg/pipelines/roles"
 )
 
 func TestCreateStatusTrackerDeployment(t *testing.T) {

--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -26,7 +26,8 @@ func createDevCDPipelineRun(saName string) pipelinev1.PipelineRun {
 func createDevCIPipelineRun(saName string) pipelinev1.PipelineRun {
 	return pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)")),
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)"),
+			statusTrackerAnnotations("dev-ci-build-from-pr", "Dev CI Build")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
 			PipelineRef:        createPipelineRef("app-ci-pipeline"),
@@ -35,7 +36,7 @@ func createDevCIPipelineRun(saName string) pipelinev1.PipelineRun {
 				createPipelineBindingParam("COMMIT_SHA", "$(params.gitsha)"),
 				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
 			},
-			Resources: createDevResource("$(params.gitref)"),
+			Resources: createDevResource("$(params.gitsha)"),
 		},
 	}
 
@@ -56,7 +57,7 @@ func createCDPipelineRun(saName string) pipelinev1.PipelineRun {
 func createCIPipelineRun(saName string) pipelinev1.PipelineRun {
 	return pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-pr-pipeline-$(uid)")),
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-pr-pipeline-$(uid)"), statusTrackerAnnotations("ci-dryrun-from-pr-pipeline", "Stage CI Dry Run")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
 			PipelineRef:        createPipelineRef("ci-dryrun-from-pr-pipeline"),
@@ -97,7 +98,7 @@ func createResources() []pipelinev1.PipelineResourceBinding {
 			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
 				Type: "git",
 				Params: []pipelinev1.ResourceParam{
-					createResourceParams("revision", "$(params.gitref)"),
+					createResourceParams("revision", "$(params.gitsha)"),
 					createResourceParams("url", "$(params.gitrepositoryurl)"),
 				},
 			},

--- a/pkg/pipelines/triggers/pipelinerun_test.go
+++ b/pkg/pipelines/triggers/pipelinerun_test.go
@@ -33,8 +33,9 @@ func TestCreateDevCDPipelineRun(t *testing.T) {
 
 func TestCreateDevCIPipelineRun(t *testing.T) {
 	validDevCIPipelineRun := pipelinev1.PipelineRun{
-		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)")),
+		TypeMeta: pipelineRunTypeMeta,
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)"),
+			statusTrackerAnnotations("dev-ci-build-from-pr", "Dev CI Build")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: sName,
 			PipelineRef:        createPipelineRef("app-ci-pipeline"),
@@ -43,7 +44,7 @@ func TestCreateDevCIPipelineRun(t *testing.T) {
 				createPipelineBindingParam("COMMIT_SHA", "$(params.gitsha)"),
 				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
 			},
-			Resources: createDevResource("$(params.gitref)"),
+			Resources: createDevResource("$(params.gitsha)"),
 		},
 	}
 	template := createDevCIPipelineRun(sName)
@@ -70,8 +71,9 @@ func TestCreateCDPipelineRun(t *testing.T) {
 
 func TestCreateStageCIPipelineRun(t *testing.T) {
 	validStageCIPipeline := pipelinev1.PipelineRun{
-		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-pr-pipeline-$(uid)")),
+		TypeMeta: pipelineRunTypeMeta,
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-pr-pipeline-$(uid)"),
+			statusTrackerAnnotations("ci-dryrun-from-pr-pipeline", "Stage CI Dry Run")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: sName,
 			PipelineRef:        createPipelineRef("ci-dryrun-from-pr-pipeline"),

--- a/pkg/pipelines/triggers/templates.go
+++ b/pkg/pipelines/triggers/templates.go
@@ -80,9 +80,8 @@ func CreateCDPushTemplate(ns, saName string) triggersv1.TriggerTemplate {
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, "cd-deploy-from-push-template")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-
-				createTemplateParamSpecDefault("gitref", "The git revision", "master"),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
+				createTemplateParamSpec("gitsha", "The specific commit SHA."),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{
@@ -103,8 +102,8 @@ func CreateCIDryRunTemplate(ns, saName string) triggersv1.TriggerTemplate {
 			statusTrackerAnnotations("ci-dryrun-from-pr-pipeline", "Stage CI Dry Run")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-				createTemplateParamSpecDefault("gitref", "The git revision", "master"),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
+				createTemplateParamSpec("gitsha", "The specific commit SHA."),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{

--- a/pkg/pipelines/triggers/templates_test.go
+++ b/pkg/pipelines/triggers/templates_test.go
@@ -100,15 +100,8 @@ func TestCreateCDPushTemplate(t *testing.T) {
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("testns", "cd-deploy-from-push-template")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-				{
-					Name:        "gitref",
-					Description: "The git revision",
-					Default:     strPtr("master"),
-				},
-				{
-					Name:        "gitrepositoryurl",
-					Description: "The git repository url",
-				},
+				{Name: "gitrepositoryurl", Description: "The git repository url"},
+				{Name: "gitsha", Description: "The specific commit SHA."},
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{
@@ -133,15 +126,8 @@ func TestCreateCIDryRunTemplate(t *testing.T) {
 
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-				{
-					Name:        "gitref",
-					Description: "The git revision",
-					Default:     strPtr("master"),
-				},
-				{
-					Name:        "gitrepositoryurl",
-					Description: "The git repository url",
-				},
+				{Name: "gitrepositoryurl", Description: "The git repository url"},
+				{Name: "gitsha", Description: "The specific commit SHA."},
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{


### PR DESCRIPTION
**What type of PR is this?**
Commit Status Tracker was inadvertently disabled during package/command re-org,   This change is to re-enable.  
/kind feature


**What does does this PR do / why we need it**:
This PR add support for commit-status tracker on guthub and gitlab. 

**Which issue(s) this PR fixes**:
Gitops-166
https://issues.redhat.com/browse/GITOPS-166

