### PR TITLE
Add .git suffix to repository URL

### DIFF
--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/cli/pipelines/utility"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/pipelines"
 	"github.com/openshift/odo/pkg/pipelines/ioutils"
@@ -49,6 +50,8 @@ func (io *BootstrapParameters) Complete(name string, cmd *cobra.Command, args []
 	if io.Prefix != "" && !strings.HasSuffix(io.Prefix, "-") {
 		io.Prefix = io.Prefix + "-"
 	}
+	io.GitOpsRepoURL = utility.AddGitSuffixIfNecessary(io.GitOpsRepoURL)
+	io.AppRepoURL = utility.AddGitSuffixIfNecessary(io.AppRepoURL)
 	return nil
 }
 

--- a/pkg/odo/cli/pipelines/bootstrap_test.go
+++ b/pkg/odo/cli/pipelines/bootstrap_test.go
@@ -34,6 +34,42 @@ func TestCompleteBootstrapParameters(t *testing.T) {
 	}
 }
 
+func TestAddSuffixWithBootstrap(t *testing.T) {
+	gitOpsURL := "https://github.com/org/gitops"
+	appURL := "https://github.com/org/app"
+	tt := []struct {
+		name           string
+		gitOpsURL      string
+		appURL         string
+		validGitOpsURL string
+		validAppURL    string
+	}{
+		{"empty string", "", "", "", ""},
+		{"suffix already exists", gitOpsURL + ".git", appURL + ".git", gitOpsURL + ".git", appURL + ".git"},
+		{"misssing suffix", gitOpsURL, appURL, gitOpsURL + ".git", appURL + ".git"},
+	}
+
+	for _, test := range tt {
+		t.Run(test.name, func(rt *testing.T) {
+			o := BootstrapParameters{&pipelines.BootstrapOptions{
+				GitOpsRepoURL: test.gitOpsURL, AppRepoURL: test.appURL},
+				&genericclioptions.Context{}}
+
+			err := o.Complete("test", &cobra.Command{}, []string{"test", "test/repo"})
+			if err != nil {
+				t.Errorf("Complete() %#v failed: ", err)
+			}
+
+			if o.GitOpsRepoURL != test.validGitOpsURL {
+				rt.Fatalf("URL mismatch: got %s, want %s", o.GitOpsRepoURL, test.validAppURL)
+			}
+			if o.AppRepoURL != test.validAppURL {
+				rt.Fatalf("URL mismatch: got %s, want %s", o.GitOpsRepoURL, test.validAppURL)
+			}
+		})
+	}
+}
+
 func TestValidateBootstrapParameters(t *testing.T) {
 	optionTests := []struct {
 		name    string

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/cli/pipelines/utility"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/pipelines"
 	"github.com/openshift/odo/pkg/pipelines/ioutils"
@@ -55,6 +56,7 @@ func (io *InitParameters) Complete(name string, cmd *cobra.Command, args []strin
 	if io.prefix != "" && !strings.HasSuffix(io.prefix, "-") {
 		io.prefix = io.prefix + "-"
 	}
+	io.gitOpsRepoURL = utility.AddGitSuffixIfNecessary(io.gitOpsRepoURL)
 	return nil
 }
 

--- a/pkg/odo/cli/pipelines/init_test.go
+++ b/pkg/odo/cli/pipelines/init_test.go
@@ -39,6 +39,32 @@ func TestCompleteInitParameters(t *testing.T) {
 	}
 }
 
+func TestAddSuffixWithInit(t *testing.T) {
+	tt := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"suffix for GitLab URL", "https://gitlab.com/test/org", "https://gitlab.com/test/org.git"},
+		{"suffix for GitHub URL", "https://github.com/test/org", "https://github.com/test/org.git"},
+		{"suffix for empty string", "", ""},
+		{"suffix already present", "https://github.com/test/org.git", "https://github.com/test/org.git"},
+	}
+
+	for _, test := range tt {
+		t.Run(test.name, func(rt *testing.T) {
+			o := InitParameters{gitOpsRepoURL: test.url}
+			err := o.Complete("test", &cobra.Command{}, []string{"test", "test/repo"})
+			if err != nil {
+				rt.Fatal(err)
+			}
+			if test.want != o.gitOpsRepoURL {
+				rt.Fatalf("URL mismatch: got %s, want %s", o.gitOpsRepoURL, test.want)
+			}
+		})
+	}
+}
+
 func TestValidateInitParameters(t *testing.T) {
 	optionTests := []struct {
 		name       string

--- a/pkg/odo/cli/pipelines/service/add.go
+++ b/pkg/odo/cli/pipelines/service/add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/odo/cli/pipelines/utility"
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/pipelines"
 	"github.com/openshift/odo/pkg/pipelines/ioutils"
@@ -41,6 +42,7 @@ type AddOptions struct {
 
 // Complete is called when the command is completed
 func (o *AddOptions) Complete(name string, cmd *cobra.Command, args []string) error {
+	o.gitRepoURL = utility.AddGitSuffixIfNecessary(o.gitRepoURL)
 	return nil
 }
 

--- a/pkg/odo/cli/pipelines/service/add_test.go
+++ b/pkg/odo/cli/pipelines/service/add_test.go
@@ -12,6 +12,32 @@ type keyValuePair struct {
 	value string
 }
 
+func TestCompleteAddOptions(t *testing.T) {
+	tt := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"service on GitLab", "https://gitlab.com/test/org", "https://gitlab.com/test/org.git"},
+		{"service on GitHub", "https://github.com/test/org", "https://github.com/test/org.git"},
+		{"service with no URL", "", ""},
+		{"suffix already present", "https://github.com/test/org.git", "https://github.com/test/org.git"},
+	}
+
+	for _, test := range tt {
+		t.Run(test.name, func(rt *testing.T) {
+			o := AddOptions{gitRepoURL: test.url}
+			err := o.Complete("test", &cobra.Command{}, []string{"test", "test/repo"})
+			if err != nil {
+				rt.Fatal(err)
+			}
+			if test.want != o.gitRepoURL {
+				rt.Fatalf("URL mismatch: got %s, want %s", o.gitRepoURL, test.want)
+			}
+		})
+	}
+}
+
 func TestAddCommandWithMissingParams(t *testing.T) {
 
 	// manifestFile := "~/pipelines.yaml"

--- a/pkg/odo/cli/pipelines/utility/utility.go
+++ b/pkg/odo/cli/pipelines/utility/utility.go
@@ -1,0 +1,16 @@
+package utility
+
+import (
+	"strings"
+
+	"github.com/openshift/odo/pkg/log"
+)
+
+// AddGitSuffixIfNecessary will append .git to URL if necessary
+func AddGitSuffixIfNecessary(url string) string {
+	if url == "" || strings.HasSuffix(strings.ToLower(url), ".git") {
+		return url
+	}
+	log.Infof("Adding .git to %s", url)
+	return url + ".git"
+}

--- a/pkg/odo/cli/pipelines/utility/utility_test.go
+++ b/pkg/odo/cli/pipelines/utility/utility_test.go
@@ -1,0 +1,25 @@
+package utility
+
+import "testing"
+
+func TestAddGitSuffix(t *testing.T) {
+	tt := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"missing git suffix", "https://github.com/test/org", "https://github.com/test/org.git"},
+		{"suffix for empty string", "", ""},
+		{"suffix already present", "https://github.com/test/org.git", "https://github.com/test/org.git"},
+		{"suffix with a different case", "https://github.com/test/org.GIT", "https://github.com/test/org.GIT"},
+	}
+
+	for _, test := range tt {
+		t.Run(test.name, func(rt *testing.T) {
+			got := AddGitSuffixIfNecessary(test.url)
+			if test.want != got {
+				rt.Fatalf("URL mismatch: got %s, want %s", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:
ArgoCD expects .git suffix in the URL.Check and add the suffix at the CLI layer

*Changes:*
1. Check if the suffix is already present
2. Check for empty strings
3. Log a message while adding the suffix

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-197
