### PR TITLE
Start a new build after push to master

### DIFF
--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -280,12 +280,3 @@ func createBootstrapService(appName, ns, name string) *corev1.Service {
 func repoToServiceName(repoName string) string {
 	return repoName + "-svc"
 }
-
-func defaultPipelines(r scm.Repository) *config.Pipelines {
-	return &config.Pipelines{
-		Integration: &config.TemplateBinding{
-			Template: appCITemplateName,
-			Bindings: []string{},
-		},
-	}
-}

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	pipelinesFile     = "pipelines.yaml"
-	bootstrapImage    = "nginxinc/nginx-unprivileged:latest"
-	appCITemplateName = "app-ci-template"
+	pipelinesFile       = "pipelines.yaml"
+	bootstrapImage      = "nginxinc/nginx-unprivileged:latest"
+	appCITemplateName   = "app-ci-template"
+	appPushTemplateName = "app-push-template"
 )
 
 // BootstrapOptions is a struct that provides the optional flags
@@ -151,11 +152,10 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 		bootstrapped = res.Merge(resources, bootstrapped)
 		k.Resources = append(k.Resources, filenames...)
 	}
-
 	// This is specific to bootstrap, because there's only one service.
 	devEnv.Services[0].Pipelines = &config.Pipelines{
 		Integration: &config.TemplateBinding{
-			Bindings: append([]string{bindingName}, devEnv.Pipelines.Integration.Bindings[:]...),
+			Bindings: append([]string{bindingName}),
 		},
 	}
 	bootstrapped[pipelinesFile] = m
@@ -199,7 +199,6 @@ func bootstrapEnvironments(repo scm.Repository, prefix, secretName string, ns ma
 				}
 				env.Apps = []*config.Application{app}
 				env.Services = []*config.Service{svc}
-				env.Pipelines = defaultPipelines(repo)
 			}
 			envs = append(envs, env)
 		}
@@ -286,7 +285,7 @@ func defaultPipelines(r scm.Repository) *config.Pipelines {
 	return &config.Pipelines{
 		Integration: &config.TemplateBinding{
 			Template: appCITemplateName,
-			Bindings: []string{r.PRBindingName()},
+			Bindings: []string{},
 		},
 	}
 }

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -60,12 +60,6 @@ func TestBootstrapManifest(t *testing.T) {
 			GitOpsURL: "https://github.com/my-org/gitops.git",
 			Environments: []*config.Environment{
 				{
-					Pipelines: &config.Pipelines{
-						Integration: &config.TemplateBinding{
-							Template: "app-ci-template",
-							Bindings: []string{"github-pr-binding"},
-						},
-					},
 					Name: "tst-dev",
 					Services: []*config.Service{
 						{
@@ -78,7 +72,7 @@ func TestBootstrapManifest(t *testing.T) {
 								},
 							},
 							Pipelines: &config.Pipelines{
-								Integration: &config.TemplateBinding{Bindings: []string{"tst-dev-http-api-svc-binding", "github-pr-binding"}},
+								Integration: &config.TemplateBinding{Bindings: []string{"tst-dev-http-api-svc-binding"}},
 							},
 						},
 					},
@@ -115,13 +109,14 @@ func TestBootstrapManifest(t *testing.T) {
 		"03-secrets/webhook-secret-tst-dev-http-api-svc.yaml",
 		"04-tasks/deploy-from-source-task.yaml",
 		"04-tasks/deploy-using-kubectl-task.yaml",
-		"05-pipelines/app-ci-pipeline.yaml",
+		"05-pipelines/application-pipeline.yaml",
 		"05-pipelines/cd-deploy-from-push-pipeline.yaml",
 		"05-pipelines/ci-dryrun-from-pr-pipeline.yaml",
 		"06-bindings/github-pr-binding.yaml",
 		"06-bindings/github-push-binding.yaml",
 		"06-bindings/tst-dev-http-api-svc-binding.yaml",
 		"07-templates/app-ci-build-pr-template.yaml",
+		"07-templates/app-push-template.yaml",
 		"07-templates/cd-deploy-from-push-template.yaml",
 		"07-templates/ci-dryrun-from-pr-template.yaml",
 		"08-eventlisteners/cicd-event-listener.yaml",

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -109,7 +109,7 @@ func TestBootstrapManifest(t *testing.T) {
 		"03-secrets/webhook-secret-tst-dev-http-api-svc.yaml",
 		"04-tasks/deploy-from-source-task.yaml",
 		"04-tasks/deploy-using-kubectl-task.yaml",
-		"05-pipelines/application-pipeline.yaml",
+		"05-pipelines/app-ci-pipeline.yaml",
 		"05-pipelines/cd-deploy-from-push-pipeline.yaml",
 		"05-pipelines/ci-dryrun-from-pr-pipeline.yaml",
 		"06-bindings/github-pr-binding.yaml",

--- a/pkg/pipelines/environment.go
+++ b/pkg/pipelines/environment.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openshift/odo/pkg/pipelines/config"
 	res "github.com/openshift/odo/pkg/pipelines/resources"
-	"github.com/openshift/odo/pkg/pipelines/scm"
 	"github.com/openshift/odo/pkg/pipelines/yaml"
 	"github.com/spf13/afero"
 )
@@ -55,13 +54,8 @@ func AddEnv(o *EnvParameters, appFs afero.Fs) error {
 func newEnvironment(m *config.Manifest, name string) (*config.Environment, error) {
 	pipelinesConfig := m.GetPipelinesConfig()
 	if pipelinesConfig != nil && m.GitOpsURL != "" {
-		r, err := scm.NewRepository(m.GitOpsURL)
-		if err != nil {
-			return nil, err
-		}
 		return &config.Environment{
-			Name:      name,
-			Pipelines: defaultPipelines(r),
+			Name: name,
 		}, nil
 	}
 

--- a/pkg/pipelines/environment_test.go
+++ b/pkg/pipelines/environment_test.go
@@ -134,12 +134,6 @@ func TestNewEnvironment(t *testing.T) {
 			name: "test-env",
 			want: &config.Environment{
 				Name: "test-env",
-				Pipelines: &config.Pipelines{
-					Integration: &config.TemplateBinding{
-						Template: appCITemplateName,
-						Bindings: []string{},
-					},
-				},
 			},
 		},
 		{
@@ -159,12 +153,6 @@ func TestNewEnvironment(t *testing.T) {
 			name: "test-env",
 			want: &config.Environment{
 				Name: "test-env",
-				Pipelines: &config.Pipelines{
-					Integration: &config.TemplateBinding{
-						Template: appCITemplateName,
-						Bindings: []string{},
-					},
-				},
 			},
 		},
 		{

--- a/pkg/pipelines/environment_test.go
+++ b/pkg/pipelines/environment_test.go
@@ -137,7 +137,7 @@ func TestNewEnvironment(t *testing.T) {
 				Pipelines: &config.Pipelines{
 					Integration: &config.TemplateBinding{
 						Template: appCITemplateName,
-						Bindings: []string{"github-pr-binding"},
+						Bindings: []string{},
 					},
 				},
 			},
@@ -162,7 +162,7 @@ func TestNewEnvironment(t *testing.T) {
 				Pipelines: &config.Pipelines{
 					Integration: &config.TemplateBinding{
 						Template: appCITemplateName,
-						Bindings: []string{"gitlab-pr-binding"},
+						Bindings: []string{},
 					},
 				},
 			},

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -89,7 +89,7 @@ const (
 	gitopsTasksPath          = "04-tasks/deploy-from-source-task.yaml"
 	appTaskPath              = "04-tasks/deploy-using-kubectl-task.yaml"
 	ciPipelinesPath          = "05-pipelines/ci-dryrun-from-pr-pipeline.yaml"
-	appCiPipelinesPath       = "05-pipelines/application-pipeline.yaml"
+	appCiPipelinesPath       = "05-pipelines/app-ci-pipeline.yaml"
 	cdPipelinesPath          = "05-pipelines/cd-deploy-from-push-pipeline.yaml"
 	prTemplatePath           = "07-templates/ci-dryrun-from-pr-template.yaml"
 	pushTemplatePath         = "07-templates/cd-deploy-from-push-template.yaml"
@@ -212,7 +212,7 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 	outputs[appTaskPath] = tasks.CreateDeployUsingKubectlTask(cicdNamespace)
 	outputs[ciPipelinesPath] = pipelines.CreateCIPipeline(meta.NamespacedName(cicdNamespace, "ci-dryrun-from-pr-pipeline"), cicdNamespace)
 	outputs[cdPipelinesPath] = pipelines.CreateCDPipeline(meta.NamespacedName(cicdNamespace, "cd-deploy-from-push-pipeline"), cicdNamespace)
-	outputs[appCiPipelinesPath] = pipelines.CreateAppCIPipeline(meta.NamespacedName(cicdNamespace, "application-pipeline"))
+	outputs[appCiPipelinesPath] = pipelines.CreateAppCIPipeline(meta.NamespacedName(cicdNamespace, "app-ci-pipeline"))
 	createTriggerBindings(repo, outputs, cicdNamespace)
 	outputs[prTemplatePath] = triggers.CreateCIDryRunTemplate(cicdNamespace, saName)
 	outputs[pushTemplatePath] = triggers.CreateCDPushTemplate(cicdNamespace, saName)

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -89,11 +89,12 @@ const (
 	gitopsTasksPath          = "04-tasks/deploy-from-source-task.yaml"
 	appTaskPath              = "04-tasks/deploy-using-kubectl-task.yaml"
 	ciPipelinesPath          = "05-pipelines/ci-dryrun-from-pr-pipeline.yaml"
-	appCiPipelinesPath       = "05-pipelines/app-ci-pipeline.yaml"
+	appCiPipelinesPath       = "05-pipelines/application-pipeline.yaml"
 	cdPipelinesPath          = "05-pipelines/cd-deploy-from-push-pipeline.yaml"
 	prTemplatePath           = "07-templates/ci-dryrun-from-pr-template.yaml"
 	pushTemplatePath         = "07-templates/cd-deploy-from-push-template.yaml"
 	appCIBuildPRTemplatePath = "07-templates/app-ci-build-pr-template.yaml"
+	appPushTemplatePath      = "07-templates/app-push-template.yaml"
 	eventListenerPath        = "08-eventlisteners/cicd-event-listener.yaml"
 	routePath                = "09-routes/gitops-webhook-event-listener.yaml"
 
@@ -211,11 +212,12 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 	outputs[appTaskPath] = tasks.CreateDeployUsingKubectlTask(cicdNamespace)
 	outputs[ciPipelinesPath] = pipelines.CreateCIPipeline(meta.NamespacedName(cicdNamespace, "ci-dryrun-from-pr-pipeline"), cicdNamespace)
 	outputs[cdPipelinesPath] = pipelines.CreateCDPipeline(meta.NamespacedName(cicdNamespace, "cd-deploy-from-push-pipeline"), cicdNamespace)
-	outputs[appCiPipelinesPath] = pipelines.CreateAppCIPipeline(meta.NamespacedName(cicdNamespace, "app-ci-pipeline"))
+	outputs[appCiPipelinesPath] = pipelines.CreateAppCIPipeline(meta.NamespacedName(cicdNamespace, "application-pipeline"))
 	createTriggerBindings(repo, outputs, cicdNamespace)
 	outputs[prTemplatePath] = triggers.CreateCIDryRunTemplate(cicdNamespace, saName)
 	outputs[pushTemplatePath] = triggers.CreateCDPushTemplate(cicdNamespace, saName)
 	outputs[appCIBuildPRTemplatePath] = triggers.CreateDevCIBuildPRTemplate(cicdNamespace, saName)
+	outputs[appPushTemplatePath] = triggers.CreateAppPushTemplate(cicdNamespace, saName)
 	outputs[eventListenerPath] = eventlisteners.Generate(repo, cicdNamespace, saName, eventlisteners.GitOpsWebhookSecret)
 	route, err := routes.Generate(cicdNamespace)
 	if err != nil {

--- a/pkg/pipelines/tekton_builder.go
+++ b/pkg/pipelines/tekton_builder.go
@@ -50,8 +50,9 @@ func (tb *tektonBuilder) Service(env *config.Environment, svc *config.Service) e
 		return err
 	}
 	pipelines := getPipelines(env, svc, repo)
-	ciTrigger := repo.CreateCITrigger(triggerName(svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, pipelines.Integration.Template, pipelines.Integration.Bindings)
-	tb.triggers = append(tb.triggers, ciTrigger)
+	ciTrigger := repo.CreateCITrigger(triggerName(svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, appCITemplateName, append(pipelines.Integration.Bindings, repo.PRBindingName()))
+	cdTrigger := repo.CreateCDTrigger("app-push-"+svc.Name, svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, appPushTemplateName, append(pipelines.Integration.Bindings, repo.PushBindingName()))
+	tb.triggers = append(tb.triggers, ciTrigger, cdTrigger)
 	return nil
 }
 

--- a/pkg/pipelines/tekton_builder_test.go
+++ b/pkg/pipelines/tekton_builder_test.go
@@ -119,7 +119,7 @@ func TestGetPipelines(t *testing.T) {
 			&config.Pipelines{
 				Integration: &config.TemplateBinding{
 					Template: "app-ci-template",
-					Bindings: []string{"github-pr-binding"},
+					Bindings: []string{},
 				},
 			},
 		},
@@ -195,8 +195,9 @@ func fakeTriggers(t *testing.T, m *config.Manifest, gitOpsRepo string) []trigger
 		repo, err := scm.NewRepository(svc.SourceURL)
 		assertNoError(t, err)
 		pipelines := getPipelines(env, svc, repo)
-		devCITrigger := repo.CreateCITrigger(fmt.Sprintf("app-ci-build-from-pr-%s", svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, pipelines.Integration.Template, pipelines.Integration.Bindings)
-		triggers = append(triggers, devCITrigger)
+		devCITrigger := repo.CreateCITrigger(fmt.Sprintf("app-ci-build-from-pr-%s", svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, appCITemplateName, append(pipelines.Integration.Bindings, repo.PRBindingName()))
+		devCDTrigger := repo.CreateCDTrigger(fmt.Sprintf("app-push-%s", svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, appPushTemplateName, append(pipelines.Integration.Bindings, repo.PushBindingName()))
+		triggers = append(triggers, devCITrigger, devCDTrigger)
 	}
 
 	return triggers
@@ -217,8 +218,7 @@ func testService() *config.Service {
 
 func testEnv(svc *config.Service, name string) *config.Environment {
 	return &config.Environment{
-		Name:      "test-" + name,
-		Pipelines: testPipelines("test"),
+		Name: "test-" + name,
 		Services: []*config.Service{
 			svc,
 		},

--- a/pkg/pipelines/tekton_builder_test.go
+++ b/pkg/pipelines/tekton_builder_test.go
@@ -109,19 +109,14 @@ func TestGetPipelines(t *testing.T) {
 			testPipelines("svc"),
 		},
 		{
-			"Default pipelines are used",
+			"Pipelines are not present in both service and environment",
 			&config.Environment{
 				Name: "test-env",
 			},
 			&config.Service{
 				Name: "test-service",
 			},
-			&config.Pipelines{
-				Integration: &config.TemplateBinding{
-					Template: "app-ci-template",
-					Bindings: []string{},
-				},
-			},
+			nil,
 		},
 		{
 			"Only override the bindings in the service",
@@ -195,6 +190,9 @@ func fakeTriggers(t *testing.T, m *config.Manifest, gitOpsRepo string) []trigger
 		repo, err := scm.NewRepository(svc.SourceURL)
 		assertNoError(t, err)
 		pipelines := getPipelines(env, svc, repo)
+		if pipelines == nil {
+			continue
+		}
 		devCITrigger := repo.CreateCITrigger(fmt.Sprintf("app-ci-build-from-pr-%s", svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, appCITemplateName, append(pipelines.Integration.Bindings, repo.PRBindingName()))
 		devCDTrigger := repo.CreateCDTrigger(fmt.Sprintf("app-push-%s", svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, appPushTemplateName, append(pipelines.Integration.Bindings, repo.PushBindingName()))
 		triggers = append(triggers, devCITrigger, devCDTrigger)

--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -11,31 +11,19 @@ var (
 	pipelineRunTypeMeta = meta.TypeMeta("PipelineRun", "tekton.dev/v1beta1")
 )
 
-func createDevCDPipelineRun(saName string) pipelinev1.PipelineRun {
-	return pipelinev1.PipelineRun{
-		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-cd-pipeline-run-$(uid)")),
-		Spec: pipelinev1.PipelineRunSpec{
-			ServiceAccountName: saName,
-			PipelineRef:        createPipelineRef("app-cd-pipeline"),
-			Resources:          createDevResource("$(params.gitsha)"),
-		},
-	}
-}
-
-func createDevCIPipelineRun(saName string) pipelinev1.PipelineRun {
+func createDevCIPipelineRun(saName, image string) pipelinev1.PipelineRun {
 	return pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunTypeMeta,
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
-			PipelineRef:        createPipelineRef("app-ci-pipeline"),
+			PipelineRef:        createPipelineRef("application-pipeline"),
 			Params: []pipelinev1.Param{
 				createPipelineBindingParam("REPO", "$(params.fullname)"),
 				createPipelineBindingParam("COMMIT_SHA", "$(params.gitsha)"),
 				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
 			},
-			Resources: createDevResource("$(params.gitref)"),
+			Resources: createDevResource("$(params.gitref)", image),
 		},
 	}
 
@@ -66,7 +54,7 @@ func createCIPipelineRun(saName string) pipelinev1.PipelineRun {
 
 }
 
-func createDevResource(revision string) []pipelinev1.PipelineResourceBinding {
+func createDevResource(revision, image string) []pipelinev1.PipelineResourceBinding {
 	return []pipelinev1.PipelineResourceBinding{
 		{
 			Name: "source-repo",
@@ -83,7 +71,7 @@ func createDevResource(revision string) []pipelinev1.PipelineResourceBinding {
 			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
 				Type: "image",
 				Params: []pipelinev1.ResourceParam{
-					createResourceParams("url", "$(params.imageRepo):$(params.gitref)-$(params.gitsha)"),
+					createResourceParams("url", image),
 				},
 			},
 		},

--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -17,7 +17,7 @@ func createDevCIPipelineRun(saName, image string) pipelinev1.PipelineRun {
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
-			PipelineRef:        createPipelineRef("application-pipeline"),
+			PipelineRef:        createPipelineRef("app-ci-pipeline"),
 			Params: []pipelinev1.Param{
 				createPipelineBindingParam("REPO", "$(params.fullname)"),
 				createPipelineBindingParam("COMMIT_SHA", "$(params.gitsha)"),

--- a/pkg/pipelines/triggers/pipelinerun_test.go
+++ b/pkg/pipelines/triggers/pipelinerun_test.go
@@ -20,7 +20,7 @@ func TestCreateDevCIPipelineRun(t *testing.T) {
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: sName,
-			PipelineRef:        createPipelineRef("application-pipeline"),
+			PipelineRef:        createPipelineRef("app-ci-pipeline"),
 			Params: []pipelinev1.Param{
 				createPipelineBindingParam("REPO", "$(params.fullname)"),
 				createPipelineBindingParam("COMMIT_SHA", "$(params.gitsha)"),

--- a/pkg/pipelines/triggers/templates.go
+++ b/pkg/pipelines/triggers/templates.go
@@ -46,7 +46,7 @@ func CreateDevCIBuildPRTemplate(ns, saName string) triggersv1.TriggerTemplate {
 		TypeMeta: triggerTemplateTypeMeta,
 		ObjectMeta: meta.ObjectMeta(
 			meta.NamespacedName(ns, "app-ci-template"),
-			statusTrackerAnnotations("application-pipeline", "Application CI Build")),
+			statusTrackerAnnotations("app-ci-pipeline", "Application CI Build")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: appTemplateParams(),
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
@@ -66,7 +66,7 @@ func CreateAppPushTemplate(ns, saName string) triggersv1.TriggerTemplate {
 	return triggersv1.TriggerTemplate{
 		TypeMeta: triggerTemplateTypeMeta,
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, "app-push-template"),
-			statusTrackerAnnotations("application-pipeline", "Application Push Build")),
+			statusTrackerAnnotations("app-ci-pipeline", "Application Push Build")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: appTemplateParams(),
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{

--- a/pkg/pipelines/triggers/templates_test.go
+++ b/pkg/pipelines/triggers/templates_test.go
@@ -51,7 +51,7 @@ func TestCreateDevCIBuildPRTemplate(t *testing.T) {
 	validdevCIPRTemplate := triggersv1.TriggerTemplate{
 		TypeMeta: triggerTemplateTypeMeta,
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("testns", "app-ci-template"),
-			statusTrackerAnnotations("dev-ci-build-from-pr", "Dev CI Build")),
+			statusTrackerAnnotations("application-pipeline", "Application CI Build")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
@@ -155,6 +155,29 @@ func TestCreateCIDryRunTemplate(t *testing.T) {
 	template := CreateCIDryRunTemplate("testns", serviceAccName)
 	if diff := cmp.Diff(validStageCIDryRunTemplate, template); diff != "" {
 		t.Fatalf("createCIdryrunptemplate failed:\n%s", diff)
+	}
+
+}
+
+func TestAppPushTemplate(t *testing.T) {
+	want := triggersv1.TriggerTemplate{
+		TypeMeta: triggerTemplateTypeMeta,
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("cicd", "app-push-template"),
+			statusTrackerAnnotations("application-pipeline", "Application Push Build")),
+		Spec: triggersv1.TriggerTemplateSpec{
+			Params: appTemplateParams(),
+			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
+				{
+					RawExtension: runtime.RawExtension{
+						Raw: createDevCDResourceTemplate("pipeline"),
+					},
+				},
+			},
+		},
+	}
+	got := CreateAppPushTemplate("cicd", "pipeline")
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("CreateAppPushPipeline failed: \n%s", diff)
 	}
 
 }

--- a/pkg/pipelines/triggers/templates_test.go
+++ b/pkg/pipelines/triggers/templates_test.go
@@ -51,7 +51,7 @@ func TestCreateDevCIBuildPRTemplate(t *testing.T) {
 	validdevCIPRTemplate := triggersv1.TriggerTemplate{
 		TypeMeta: triggerTemplateTypeMeta,
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("testns", "app-ci-template"),
-			statusTrackerAnnotations("application-pipeline", "Application CI Build")),
+			statusTrackerAnnotations("app-ci-pipeline", "Application CI Build")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
@@ -163,7 +163,7 @@ func TestAppPushTemplate(t *testing.T) {
 	want := triggersv1.TriggerTemplate{
 		TypeMeta: triggerTemplateTypeMeta,
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("cicd", "app-push-template"),
-			statusTrackerAnnotations("application-pipeline", "Application Push Build")),
+			statusTrackerAnnotations("app-ci-pipeline", "Application Push Build")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: appTemplateParams(),
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What does this PR do / why we need it**:
Currently, we do not build a new image when the PR is merged. The image generated from PR can be outdated since it doesn't include the changes in master. This PR will enable the existing pipeline to start a new build to push events. The pipeline will create a new image capturing the updated changes in master

*Changes:*
1. Added a new trigger in the event listener which will respond to push event
2. Added a new template that will create a pipeline run for triggering the existing app pipeline
3. Default pipeline is not generated since we have bindings for both PR and Push events
4. Triggers are not created if bindings are not present

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-200
