### PR TITLE
Allow configuration of sealed secrets

### DIFF
--- a/pkg/odo/cli/pipelines/bootstrap_test.go
+++ b/pkg/odo/cli/pipelines/bootstrap_test.go
@@ -20,7 +20,10 @@ func TestCompleteBootstrapParameters(t *testing.T) {
 	}
 
 	for _, tt := range completeTests {
-		o := BootstrapParameters{&pipelines.BootstrapOptions{Prefix: tt.prefix}, &genericclioptions.Context{}}
+		o := BootstrapParameters{
+			&pipelines.BootstrapOptions{InitOptions: pipelines.InitOptions{Prefix: tt.prefix}},
+			&genericclioptions.Context{},
+		}
 
 		err := o.Complete("test", &cobra.Command{}, []string{"test", "test/repo"})
 
@@ -51,8 +54,10 @@ func TestAddSuffixWithBootstrap(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.name, func(rt *testing.T) {
-			o := BootstrapParameters{&pipelines.BootstrapOptions{
-				GitOpsRepoURL: test.gitOpsURL, AppRepoURL: test.appURL},
+			o := BootstrapParameters{
+				&pipelines.BootstrapOptions{
+					InitOptions: pipelines.InitOptions{GitOpsRepoURL: test.gitOpsURL},
+					AppRepoURL:  test.appURL},
 				&genericclioptions.Context{}}
 
 			err := o.Complete("test", &cobra.Command{}, []string{"test", "test/repo"})
@@ -83,9 +88,7 @@ func TestValidateBootstrapParameters(t *testing.T) {
 	for _, tt := range optionTests {
 		o := BootstrapParameters{
 			&pipelines.BootstrapOptions{
-				GitOpsRepoURL: tt.gitRepo,
-				Prefix:        "test",
-			},
+				InitOptions: pipelines.InitOptions{GitOpsRepoURL: tt.gitRepo, Prefix: "test"}},
 			&genericclioptions.Context{},
 		}
 		err := o.Validate()

--- a/pkg/odo/cli/pipelines/service/add.go
+++ b/pkg/odo/cli/pipelines/service/add.go
@@ -25,56 +25,38 @@ var (
 	addShortDesc = `Add a new service`
 )
 
-// AddOptions encapsulates the parameters for service add command
-type AddOptions struct {
-	appName                  string
-	envName                  string
-	gitRepoURL               string
-	imageRepo                string
-	internalRegistryHostname string
-	pipelinesFilePath        string
-	serviceName              string
-	webhookSecret            string
-
+// AddServiceOptions encapsulates the parameters for service add command
+type AddServiceOptions struct {
+	*pipelines.AddServiceOptions
 	// generic context options common to all commands
 	*genericclioptions.Context
 }
 
 // Complete is called when the command is completed
-func (o *AddOptions) Complete(name string, cmd *cobra.Command, args []string) error {
-	o.gitRepoURL = utility.AddGitSuffixIfNecessary(o.gitRepoURL)
+func (o *AddServiceOptions) Complete(name string, cmd *cobra.Command, args []string) error {
+	o.GitRepoURL = utility.AddGitSuffixIfNecessary(o.GitRepoURL)
 	return nil
 }
 
 // Validate validates the parameters of the EnvParameters.
-func (o *AddOptions) Validate() error {
+func (o *AddServiceOptions) Validate() error {
 	return nil
 }
 
 // Run runs the project bootstrap command.
-func (o *AddOptions) Run() error {
-
-	err := pipelines.AddService(&pipelines.AddServiceParameters{
-		AppName:                  o.appName,
-		EnvName:                  o.envName,
-		GitRepoURL:               o.gitRepoURL,
-		ImageRepo:                o.imageRepo,
-		InternalRegistryHostname: o.internalRegistryHostname,
-		PipelinesFilePath:        o.pipelinesFilePath,
-		ServiceName:              o.serviceName,
-		WebhookSecret:            o.webhookSecret,
-	}, ioutils.NewFilesystem())
+func (o *AddServiceOptions) Run() error {
+	err := pipelines.AddService(o.AddServiceOptions, ioutils.NewFilesystem())
 
 	if err != nil {
 		return err
 	}
-	log.Successf("Created Service %s sucessfully at environment %s.", o.serviceName, o.envName)
+	log.Successf("Created Service %s sucessfully at environment %s.", o.ServiceName, o.EnvName)
 	return nil
 
 }
 
 func newCmdAdd(name, fullName string) *cobra.Command {
-	o := &AddOptions{}
+	o := &AddServiceOptions{AddServiceOptions: &pipelines.AddServiceOptions{}}
 
 	cmd := &cobra.Command{
 		Use:     name,
@@ -86,14 +68,14 @@ func newCmdAdd(name, fullName string) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&o.gitRepoURL, "git-repo-url", "", "source Git repository URL")
-	cmd.Flags().StringVar(&o.webhookSecret, "webhook-secret", "", "source Git repository webhook secret")
-	cmd.Flags().StringVar(&o.appName, "app-name", "", "the name of the application where the service will be added")
-	cmd.Flags().StringVar(&o.serviceName, "service-name", "", "the name of the service to be added")
-	cmd.Flags().StringVar(&o.envName, "env-name", "", "the name of the environment where the service will be added")
-	cmd.Flags().StringVar(&o.imageRepo, "image-repo", "", "used to push built images")
-	cmd.Flags().StringVar(&o.internalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
-	cmd.Flags().StringVar(&o.pipelinesFilePath, "pipelines-file", "pipelines.yaml", "path to pipelines file")
+	cmd.Flags().StringVar(&o.GitRepoURL, "git-repo-url", "", "source Git repository URL")
+	cmd.Flags().StringVar(&o.WebhookSecret, "webhook-secret", "", "source Git repository webhook secret")
+	cmd.Flags().StringVar(&o.AppName, "app-name", "", "the name of the application where the service will be added")
+	cmd.Flags().StringVar(&o.ServiceName, "service-name", "", "the name of the service to be added")
+	cmd.Flags().StringVar(&o.EnvName, "env-name", "", "the name of the environment where the service will be added")
+	cmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "used to push built images")
+	cmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
+	cmd.Flags().StringVar(&o.PipelinesFilePath, "pipelines-file", "pipelines.yaml", "path to pipelines file")
 
 	// required flags
 	_ = cmd.MarkFlagRequired("service-name")

--- a/pkg/odo/cli/pipelines/service/add_test.go
+++ b/pkg/odo/cli/pipelines/service/add_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/openshift/odo/pkg/pipelines"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +14,7 @@ type keyValuePair struct {
 }
 
 func TestCompleteAddOptions(t *testing.T) {
-	tt := []struct {
+	completeTests := []struct {
 		name string
 		url  string
 		want string
@@ -24,23 +25,21 @@ func TestCompleteAddOptions(t *testing.T) {
 		{"suffix already present", "https://github.com/test/org.git", "https://github.com/test/org.git"},
 	}
 
-	for _, test := range tt {
-		t.Run(test.name, func(rt *testing.T) {
-			o := AddOptions{gitRepoURL: test.url}
+	for _, tt := range completeTests {
+		t.Run(tt.name, func(rt *testing.T) {
+			o := AddServiceOptions{AddServiceOptions: &pipelines.AddServiceOptions{GitRepoURL: tt.url}}
 			err := o.Complete("test", &cobra.Command{}, []string{"test", "test/repo"})
 			if err != nil {
 				rt.Fatal(err)
 			}
-			if test.want != o.gitRepoURL {
-				rt.Fatalf("URL mismatch: got %s, want %s", o.gitRepoURL, test.want)
+			if tt.want != o.GitRepoURL {
+				rt.Fatalf("URL mismatch: got %s, want %s", o.GitRepoURL, tt.want)
 			}
 		})
 	}
 }
 
 func TestAddCommandWithMissingParams(t *testing.T) {
-
-	// manifestFile := "~/pipelines.yaml"
 	cmdTests := []struct {
 		desc    string
 		flags   []keyValuePair

--- a/pkg/odo/cli/pipelines/utility/utility.go
+++ b/pkg/odo/cli/pipelines/utility/utility.go
@@ -14,3 +14,22 @@ func AddGitSuffixIfNecessary(url string) string {
 	log.Infof("Adding .git to %s", url)
 	return url + ".git"
 }
+
+// RemoveEmptyStrings returns a slice with all the empty strings removed from the
+// source slice.
+func RemoveEmptyStrings(s []string) []string {
+	nonempty := []string{}
+	for _, v := range s {
+		if v != "" {
+			nonempty = append(nonempty, v)
+		}
+	}
+	return nonempty
+}
+
+func MaybeCompletePrefix(s string) string {
+	if s != "" && !strings.HasSuffix(s, "-") {
+		return s + "-"
+	}
+	return s
+}

--- a/pkg/odo/cli/pipelines/utility/utility_test.go
+++ b/pkg/odo/cli/pipelines/utility/utility_test.go
@@ -1,9 +1,13 @@
 package utility
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestAddGitSuffix(t *testing.T) {
-	tt := []struct {
+	addSuffixTests := []struct {
 		name string
 		url  string
 		want string
@@ -14,11 +18,52 @@ func TestAddGitSuffix(t *testing.T) {
 		{"suffix with a different case", "https://github.com/test/org.GIT", "https://github.com/test/org.GIT"},
 	}
 
-	for _, test := range tt {
-		t.Run(test.name, func(rt *testing.T) {
-			got := AddGitSuffixIfNecessary(test.url)
-			if test.want != got {
-				rt.Fatalf("URL mismatch: got %s, want %s", got, test.want)
+	for _, tt := range addSuffixTests {
+		t.Run(tt.name, func(rt *testing.T) {
+			got := AddGitSuffixIfNecessary(tt.url)
+			if tt.want != got {
+				rt.Fatalf("URL mismatch: got %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveEmptyStrings(t *testing.T) {
+	stringsTests := []struct {
+		name   string
+		source []string
+		want   []string
+	}{
+		{"no strings", []string{}, []string{}},
+		{"no empty strings", []string{"test1", "test2"}, []string{"test1", "test2"}},
+		{"mixed strings", []string{"", "test2", ""}, []string{"test2"}},
+	}
+
+	for _, tt := range stringsTests {
+		t.Run(tt.name, func(rt *testing.T) {
+			got := RemoveEmptyStrings(tt.source)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				rt.Fatalf("string removal failed:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMaybeCompletePrefix(t *testing.T) {
+	stringsTests := []struct {
+		name   string
+		prefix string
+		want   string
+	}{
+		{"with dash on end", "testing-", "testing-"},
+		{"with no dash on end", "testing", "testing-"},
+	}
+
+	for _, tt := range stringsTests {
+		t.Run(tt.name, func(rt *testing.T) {
+			got := MaybeCompletePrefix(tt.prefix)
+			if tt.want != got {
+				rt.Fatalf("prefixing failed, got %#v, want %#v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -26,7 +26,7 @@ func TestBootstrapManifest(t *testing.T) {
 		secrets.DefaultPublicKeyFunc = f
 	}(secrets.DefaultPublicKeyFunc)
 
-	secrets.DefaultPublicKeyFunc = func() (*rsa.PublicKey, error) {
+	secrets.DefaultPublicKeyFunc = func(ns string) (*rsa.PublicKey, error) {
 		key, err := rsa.GenerateKey(rand.Reader, 1024)
 		if err != nil {
 			t.Fatalf("failed to generate a private RSA key: %s", err)
@@ -35,19 +35,21 @@ func TestBootstrapManifest(t *testing.T) {
 	}
 
 	params := &BootstrapOptions{
-		Prefix:              "tst-",
-		GitOpsRepoURL:       testGitOpsRepo,
-		GitOpsWebhookSecret: "123",
-		AppRepoURL:          testSvcRepo,
-		ImageRepo:           "image/repo",
-		AppWebhookSecret:    "456",
+		InitOptions: InitOptions{
+			Prefix:              "tst-",
+			GitOpsRepoURL:       testGitOpsRepo,
+			GitOpsWebhookSecret: "123",
+			ImageRepo:           "image/repo",
+		},
+		AppRepoURL:       testSvcRepo,
+		AppWebhookSecret: "456",
 	}
 
 	r, err := bootstrapResources(params, ioutils.NewMapFilesystem())
 	if err != nil {
 		t.Fatal(err)
 	}
-	hookSecret, err := secrets.CreateSealedSecret(meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api-svc"), "456", eventlisteners.WebhookSecretKey)
+	hookSecret, err := secrets.CreateSealedSecret(meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api-svc"), "456", eventlisteners.WebhookSecretKey, "test-ns")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What does does this PR do / why we need it**:

Installation of SealedSecrets via the hub operator means that it doesn't go into the standard namespace (`kube-system`) this adds a command-line option where the user is required to provide the namespace for the sealed secrets operator.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
