### PR TITLE
Default the dockerconfigjson to $HOME/.docker/config.json

### DIFF
--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -100,7 +100,7 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVar(&o.ServiceRepoURL, "service-repo-url", "", "Service source e.g. https://github.com/organisation/service")
 	bootstrapCmd.Flags().StringVar(&o.ServiceWebhookSecret, "service-webhook-secret", "", "Provide the GitHub webhook secret for Service repository (if not provided, it will be auto-generated)")
 
-	bootstrapCmd.Flags().StringVar(&o.DockerConfigJSONFilename, "dockercfgjson", "~/.docker/config.json", "provide the dockercfgjson path")
+	bootstrapCmd.Flags().StringVar(&o.DockerConfigJSONFilename, "dockercfgjson", "~/.docker/config.json", "authenticates the image push to the desired image registry, path to config.json")
 	bootstrapCmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	bootstrapCmd.Flags().StringVar(&o.OutputPath, "output", ".", "folder path to add Gitops resources")
 	bootstrapCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "add a prefix to the environment names")
@@ -110,7 +110,6 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.MarkFlagRequired("gitops-repo-url")
 	bootstrapCmd.MarkFlagRequired("service-repo-url")
 	bootstrapCmd.MarkFlagRequired("image-repo")
-	bootstrapCmd.MarkFlagRequired("sealed-secrets-ns")
 
 	return bootstrapCmd
 }

--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -109,8 +109,8 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "kube-system", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
 	bootstrapCmd.MarkFlagRequired("gitops-repo-url")
 	bootstrapCmd.MarkFlagRequired("service-repo-url")
-	bootstrapCmd.MarkFlagRequired("dockercfgjson")
 	bootstrapCmd.MarkFlagRequired("image-repo")
+	bootstrapCmd.MarkFlagRequired("sealed-secrets-ns")
 
 	return bootstrapCmd
 }

--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -100,11 +100,11 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVar(&o.ServiceRepoURL, "service-repo-url", "", "Service source e.g. https://github.com/organisation/service")
 	bootstrapCmd.Flags().StringVar(&o.ServiceWebhookSecret, "service-webhook-secret", "", "Provide the GitHub webhook secret for Service repository (if not provided, it will be auto-generated)")
 
-	bootstrapCmd.Flags().StringVar(&o.DockerConfigJSONFilename, "dockercfgjson", "", "provide the dockercfgjson path")
+	bootstrapCmd.Flags().StringVar(&o.DockerConfigJSONFilename, "dockercfgjson", "~/.docker/config.json", "provide the dockercfgjson path")
 	bootstrapCmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
-	bootstrapCmd.Flags().StringVar(&o.OutputPath, "output", ".", "Folder path to add Gitops resources")
-	bootstrapCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "Add a prefix to the environment names")
-	bootstrapCmd.Flags().StringVarP(&o.ImageRepo, "image-repo", "", "", "Used to push built images")
+	bootstrapCmd.Flags().StringVar(&o.OutputPath, "output", ".", "folder path to add Gitops resources")
+	bootstrapCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "add a prefix to the environment names")
+	bootstrapCmd.Flags().StringVarP(&o.ImageRepo, "image-repo", "", "", "used to push built images")
 
 	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "kube-system", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
 	bootstrapCmd.MarkFlagRequired("gitops-repo-url")

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -96,10 +96,9 @@ func NewCmdInit(name, fullName string) *cobra.Command {
 	initCmd.Flags().StringVar(&o.GitOpsWebhookSecret, "gitops-webhook-secret", "", "provide the GitHub webhook secret for GitOps repository (if not provided, it will be auto-generated)")
 	initCmd.Flags().StringVar(&o.OutputPath, "output", ".", "folder path to add GitOps resources")
 	initCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "add a prefix to the environment names")
-	initCmd.Flags().StringVar(&o.DockerConfigJSONFilename, "dockercfgjson", "", "dockercfg json pathname")
+	initCmd.Flags().StringVar(&o.DockerConfigJSONFilename, "dockercfgjson", "~/.docker/config.json", "authenticates the image push to the desired image registry, path to config.json")
 	initCmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	initCmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "image repository in this form <registry>/<username>/<repository> or <project>/<app> for internal registry")
 	initCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "kube-system", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
-
 	return initCmd
 }

--- a/pkg/odo/cli/pipelines/init_test.go
+++ b/pkg/odo/cli/pipelines/init_test.go
@@ -100,6 +100,10 @@ func TestInitCommandWithMissingParams(t *testing.T) {
 			[]keyValuePair{flag("output", "~/output"), flag("sealed-secrets-ns", "testing"),
 				flag("gitops-webhook-secret", "123")},
 			`required flag(s) "gitops-repo-url" not set`},
+		{"Missing sealed-secrets-ns flag",
+			[]keyValuePair{flag("gitops-repo-url", "https://github.com/org/sample"), flag("output", "~/output"),
+				flag("skip-checks", "true"), flag("gitops-webhook-secret", "123")},
+			`required flag(s) "sealed-secrets-ns" not set`},
 	}
 	for _, tt := range cmdTests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/pkg/odo/cli/pipelines/init_test.go
+++ b/pkg/odo/cli/pipelines/init_test.go
@@ -100,10 +100,6 @@ func TestInitCommandWithMissingParams(t *testing.T) {
 			[]keyValuePair{flag("output", "~/output"), flag("sealed-secrets-ns", "testing"),
 				flag("gitops-webhook-secret", "123")},
 			`required flag(s) "gitops-repo-url" not set`},
-		{"Missing sealed-secrets-ns flag",
-			[]keyValuePair{flag("gitops-repo-url", "https://github.com/org/sample"), flag("output", "~/output"),
-				flag("skip-checks", "true"), flag("gitops-webhook-secret", "123")},
-			`required flag(s) "sealed-secrets-ns" not set`},
 	}
 	for _, tt := range cmdTests {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What does does this PR do / why we need it**:
Default the dockerconfigjson to $HOME/.docker/config.json

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-206

