### PR TITLE
Replace pull_request events by push

### DIFF
--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -283,7 +283,7 @@ func defaultPipelines(r scm.Repository) *config.Pipelines {
 	return &config.Pipelines{
 		Integration: &config.TemplateBinding{
 			Template: appCITemplateName,
-			Bindings: []string{r.PRBindingName()},
+			Bindings: []string{r.BindingName()},
 		},
 	}
 }

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -65,7 +65,7 @@ func TestBootstrapManifest(t *testing.T) {
 					Pipelines: &config.Pipelines{
 						Integration: &config.TemplateBinding{
 							Template: "app-ci-template",
-							Bindings: []string{"github-pr-binding"},
+							Bindings: []string{"github-binding"},
 						},
 					},
 					Name: "tst-dev",
@@ -80,7 +80,7 @@ func TestBootstrapManifest(t *testing.T) {
 								},
 							},
 							Pipelines: &config.Pipelines{
-								Integration: &config.TemplateBinding{Bindings: []string{"tst-dev-http-api-binding", "github-pr-binding"}},
+								Integration: &config.TemplateBinding{Bindings: []string{"tst-dev-http-api-binding", "github-binding"}},
 							},
 						},
 					},
@@ -120,8 +120,7 @@ func TestBootstrapManifest(t *testing.T) {
 		"05-pipelines/app-ci-pipeline.yaml",
 		"05-pipelines/cd-deploy-from-push-pipeline.yaml",
 		"05-pipelines/ci-dryrun-from-pr-pipeline.yaml",
-		"06-bindings/github-pr-binding.yaml",
-		"06-bindings/github-push-binding.yaml",
+		"06-bindings/github-binding.yaml",
 		"06-bindings/tst-dev-http-api-binding.yaml",
 		"07-templates/app-ci-build-pr-template.yaml",
 		"07-templates/cd-deploy-from-push-template.yaml",

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -65,7 +65,7 @@ func TestBootstrapManifest(t *testing.T) {
 					Pipelines: &config.Pipelines{
 						Integration: &config.TemplateBinding{
 							Template: "app-ci-template",
-							Bindings: []string{"github-binding"},
+							Bindings: []string{"github-push-binding"},
 						},
 					},
 					Name: "tst-dev",
@@ -80,7 +80,7 @@ func TestBootstrapManifest(t *testing.T) {
 								},
 							},
 							Pipelines: &config.Pipelines{
-								Integration: &config.TemplateBinding{Bindings: []string{"tst-dev-http-api-binding", "github-binding"}},
+								Integration: &config.TemplateBinding{Bindings: []string{"tst-dev-http-api-binding", "github-push-binding"}},
 							},
 						},
 					},
@@ -120,7 +120,7 @@ func TestBootstrapManifest(t *testing.T) {
 		"05-pipelines/app-ci-pipeline.yaml",
 		"05-pipelines/cd-deploy-from-push-pipeline.yaml",
 		"05-pipelines/ci-dryrun-from-pr-pipeline.yaml",
-		"06-bindings/github-binding.yaml",
+		"06-bindings/github-push-binding.yaml",
 		"06-bindings/tst-dev-http-api-binding.yaml",
 		"07-templates/app-ci-build-pr-template.yaml",
 		"07-templates/cd-deploy-from-push-template.yaml",

--- a/pkg/pipelines/environment_test.go
+++ b/pkg/pipelines/environment_test.go
@@ -137,7 +137,7 @@ func TestNewEnvironment(t *testing.T) {
 				Pipelines: &config.Pipelines{
 					Integration: &config.TemplateBinding{
 						Template: appCITemplateName,
-						Bindings: []string{"github-pr-binding"},
+						Bindings: []string{"github-binding"},
 					},
 				},
 			},
@@ -162,7 +162,7 @@ func TestNewEnvironment(t *testing.T) {
 				Pipelines: &config.Pipelines{
 					Integration: &config.TemplateBinding{
 						Template: appCITemplateName,
-						Bindings: []string{"gitlab-pr-binding"},
+						Bindings: []string{"gitlab-binding"},
 					},
 				},
 			},

--- a/pkg/pipelines/environment_test.go
+++ b/pkg/pipelines/environment_test.go
@@ -137,7 +137,7 @@ func TestNewEnvironment(t *testing.T) {
 				Pipelines: &config.Pipelines{
 					Integration: &config.TemplateBinding{
 						Template: appCITemplateName,
-						Bindings: []string{"github-binding"},
+						Bindings: []string{"github-push-binding"},
 					},
 				},
 			},
@@ -162,7 +162,7 @@ func TestNewEnvironment(t *testing.T) {
 				Pipelines: &config.Pipelines{
 					Integration: &config.TemplateBinding{
 						Template: appCITemplateName,
-						Bindings: []string{"gitlab-binding"},
+						Bindings: []string{"gitlab-push-binding"},
 					},
 				},
 			},

--- a/pkg/pipelines/eventlisteners/eventlisteners.go
+++ b/pkg/pipelines/eventlisteners/eventlisteners.go
@@ -29,8 +29,8 @@ func Generate(repo scm.Repository, ns, saName, secretName string) triggersv1.Eve
 			ServiceAccountName: saName,
 			Triggers: []triggersv1.EventListenerTrigger{
 				repo.CreateCITrigger("ci-dryrun-from-pr", secretName, ns, "ci-dryrun-from-pr-template",
-					[]string{"github-pr-binding"}),
-				repo.CreateCDTrigger("cd-deploy-from-push", secretName, ns, "cd-deploy-from-push-template", []string{"github-push-binding"}),
+					[]string{"github-binding"}),
+				repo.CreateCDTrigger("cd-deploy-from-push", secretName, ns, "cd-deploy-from-push-template", []string{"github-binding"}),
 			},
 		},
 	}

--- a/pkg/pipelines/eventlisteners/eventlisteners_test.go
+++ b/pkg/pipelines/eventlisteners/eventlisteners_test.go
@@ -33,7 +33,7 @@ func TestGenerateEventListener(t *testing.T) {
 						},
 						{
 							CEL: &triggersv1.CELInterceptor{
-								Filter: "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'org/test') && !body.ref.endsWith(body.repository.default_branch)",
+								Filter: "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'org/test') && body.ref != 'refs/heads/'+body.repository.default_branch",
 								Overlays: []triggersv1.CELOverlay{
 									{Key: "ref", Expression: "split(body.ref,'/')[2]"},
 								},
@@ -63,7 +63,7 @@ func TestGenerateEventListener(t *testing.T) {
 						},
 						{
 							CEL: &triggersv1.CELInterceptor{
-								Filter: "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'org/test') && body.ref.endsWith(body.repository.default_branch)",
+								Filter: "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'org/test') && body.ref == 'refs/heads/'+body.repository.default_branch",
 								Overlays: []triggersv1.CELOverlay{
 									{Key: "ref", Expression: "split(body.ref,'/')[2]"},
 								},

--- a/pkg/pipelines/eventlisteners/eventlisteners_test.go
+++ b/pkg/pipelines/eventlisteners/eventlisteners_test.go
@@ -23,11 +23,6 @@ func TestGenerateEventListener(t *testing.T) {
 					Name: "ci-dryrun-from-pr",
 					Interceptors: []*triggersv1.EventInterceptor{
 						{
-							CEL: &triggersv1.CELInterceptor{
-								Filter: "(header.match('X-GitHub-Event', 'pull_request') && body.action == 'opened' || body.action == 'synchronize') && body.pull_request.head.repo.full_name == 'org/test'",
-							},
-						},
-						{
 							GitHub: &triggersv1.GitHubInterceptor{
 								SecretRef: &triggersv1.SecretRef{
 									SecretName: "test",
@@ -36,10 +31,18 @@ func TestGenerateEventListener(t *testing.T) {
 								},
 							},
 						},
+						{
+							CEL: &triggersv1.CELInterceptor{
+								Filter: "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'org/test') && !body.ref.endsWith(body.repository.default_branch)",
+								Overlays: []triggersv1.CELOverlay{
+									{Key: "ref", Expression: "split(body.ref,'/')[2]"},
+								},
+							},
+						},
 					},
 					Bindings: []*triggersv1.EventListenerBinding{
 						{
-							Name: "github-pr-binding",
+							Name: "github-binding",
 						},
 					},
 					Template: triggersv1.EventListenerTemplate{
@@ -50,11 +53,6 @@ func TestGenerateEventListener(t *testing.T) {
 					Name: "cd-deploy-from-push",
 					Interceptors: []*triggersv1.EventInterceptor{
 						{
-							CEL: &triggersv1.CELInterceptor{
-								Filter: "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'org/test') && body.ref.startsWith('refs/heads/master')",
-							},
-						},
-						{
 							GitHub: &triggersv1.GitHubInterceptor{
 								SecretRef: &triggersv1.SecretRef{
 									SecretName: "test",
@@ -63,10 +61,18 @@ func TestGenerateEventListener(t *testing.T) {
 								},
 							},
 						},
+						{
+							CEL: &triggersv1.CELInterceptor{
+								Filter: "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'org/test') && body.ref.endsWith(body.repository.default_branch)",
+								Overlays: []triggersv1.CELOverlay{
+									{Key: "ref", Expression: "split(body.ref,'/')[2]"},
+								},
+							},
+						},
 					},
 					Bindings: []*triggersv1.EventListenerBinding{
 						{
-							Name: "github-push-binding",
+							Name: "github-binding",
 						},
 					},
 					Template: triggersv1.EventListenerTemplate{

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -234,10 +234,8 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 
 // Trigger bindings for repository types will be created during bootstrap
 func createTriggerBindings(r scm.Repository, outputs res.Resources, ns string) {
-	prBinding, prBindingName := r.CreatePRBinding(ns)
-	outputs[filepath.Join("06-bindings", prBindingName+".yaml")] = prBinding
-	pushBinding, pushBindingName := r.CreatePushBinding(ns)
-	outputs[filepath.Join("06-bindings", pushBindingName+".yaml")] = pushBinding
+	binding, bindingName := r.CreateBinding(ns)
+	outputs[filepath.Join("06-bindings", bindingName+".yaml")] = binding
 }
 
 func createManifest(gitOpsRepoURL string, configEnv *config.Config, envs ...*config.Environment) *config.Manifest {

--- a/pkg/pipelines/scm/github.go
+++ b/pkg/pipelines/scm/github.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	githubCIDryRunFilters = "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == '%s') && !body.ref.endsWith(body.repository.default_branch)"
-	githubCDDeployFilters = "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == '%s') && body.ref.endsWith(body.repository.default_branch)"
+	githubCIDryRunFilters = "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == '%s') && body.ref != 'refs/heads/'+body.repository.default_branch"
+	githubCDDeployFilters = "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == '%s') && body.ref == 'refs/heads/'+body.repository.default_branch"
 	githubType            = "github"
 )
 
@@ -26,7 +26,7 @@ func newGitHub(rawURL string) (Repository, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &repository{url: rawURL, path: path, spec: &githubSpec{binding: "github-binding"}}, nil
+	return &repository{url: rawURL, path: path, spec: &githubSpec{binding: "github-push-binding"}}, nil
 }
 
 func proccessGitHubPath(parsedURL *url.URL) (string, error) {

--- a/pkg/pipelines/scm/github_test.go
+++ b/pkg/pipelines/scm/github_test.go
@@ -16,7 +16,7 @@ func TestCreateBindingForGithub(t *testing.T) {
 	want := triggersv1.TriggerBinding{
 		TypeMeta: triggers.TriggerBindingTypeMeta,
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "github-binding",
+			Name:      "github-push-binding",
 			Namespace: "testns",
 		},
 		Spec: triggersv1.TriggerBindingSpec{
@@ -29,8 +29,8 @@ func TestCreateBindingForGithub(t *testing.T) {
 		},
 	}
 	got, name := repo.CreateBinding("testns")
-	if name != "github-binding" {
-		t.Fatalf("CreateBinding() returned a wrong binding: want %v got %v", "github-binding", name)
+	if name != "github-push-binding" {
+		t.Fatalf("CreateBinding() returned a wrong binding: want %v got %v", "github-push-binding", name)
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("CreateBinding() failed:\n%s", diff)

--- a/pkg/pipelines/scm/gitlab.go
+++ b/pkg/pipelines/scm/gitlab.go
@@ -8,14 +8,13 @@ import (
 )
 
 const (
-	gitlabCIDryRunFilters = "header.match('X-Gitlab-Event','Merge Request Hook') && body.object_attributes.state == 'opened' && body.project.path_with_namespace == '%s'  && body.project.default_branch == body.object_attributes.target_branch"
+	gitlabCIDryRunFilters = "header.match('X-Gitlab-Event','Push Hook') && body.project.path_with_namespace == '%s' && !body.ref.endsWith(body.project.default_branch)"
 	gitlabCDDeployFilters = "header.match('X-Gitlab-Event','Push Hook') && body.project.path_with_namespace == '%s' && body.ref.endsWith(body.project.default_branch)"
 	gitlabType            = "gitlab"
 )
 
 type gitlabSpec struct {
-	prBinding   string
-	pushBinding string
+	binding string
 }
 
 func init() {
@@ -27,7 +26,7 @@ func newGitLab(rawURL string) (Repository, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &repository{url: rawURL, path: path, spec: &gitlabSpec{prBinding: "gitlab-pr-binding", pushBinding: "gitlab-push-binding"}}, nil
+	return &repository{url: rawURL, path: path, spec: &gitlabSpec{binding: "gitlab-binding"}}, nil
 }
 
 func proccessGitLabPath(parsedURL *url.URL) (string, error) {
@@ -42,28 +41,16 @@ func proccessGitLabPath(parsedURL *url.URL) (string, error) {
 	return path, nil
 }
 
-func (r *gitlabSpec) prBindingName() string {
-	return r.prBinding
+func (r *gitlabSpec) bindingName() string {
+	return r.binding
 }
 
-func (r *gitlabSpec) pushBindingName() string {
-	return r.pushBinding
-}
-
-func (r *gitlabSpec) prBindingParams() []triggersv1.Param {
-	return []triggersv1.Param{
-		createBindingParam("gitref", "$(body.object_attributes.source_branch)"),
-		createBindingParam("gitsha", "$(body.object_attributes.last_commit.id)"),
-		createBindingParam("gitrepositoryurl", "$(body.project.git_http_url)"),
-		createBindingParam("fullname", "$(body.project.path_with_namespace)"),
-	}
-}
-
-func (r *gitlabSpec) pushBindingParams() []triggersv1.Param {
+func (r *gitlabSpec) bindingParams() []triggersv1.Param {
 	return []triggersv1.Param{
 		createBindingParam("gitref", "$(body.ref)"),
 		createBindingParam("gitsha", "$(body.after)"),
 		createBindingParam("gitrepositoryurl", "$(body.project.git_http_url)"),
+		createBindingParam("fullname", "$(body.project.path_with_namespace)"),
 	}
 }
 

--- a/pkg/pipelines/scm/gitlab.go
+++ b/pkg/pipelines/scm/gitlab.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	gitlabCIDryRunFilters = "header.match('X-Gitlab-Event','Push Hook') && body.project.path_with_namespace == '%s' && !body.ref.endsWith(body.project.default_branch)"
-	gitlabCDDeployFilters = "header.match('X-Gitlab-Event','Push Hook') && body.project.path_with_namespace == '%s' && body.ref.endsWith(body.project.default_branch)"
+	gitlabCIDryRunFilters = "header.match('X-Gitlab-Event','Push Hook') && body.project.path_with_namespace == '%s' && body.ref != 'refs/heads/'+body.project.default_branch"
+	gitlabCDDeployFilters = "header.match('X-Gitlab-Event','Push Hook') && body.project.path_with_namespace == '%s' && body.ref == 'refs/heads/'+body.project.default_branch"
 	gitlabType            = "gitlab"
 )
 
@@ -26,7 +26,7 @@ func newGitLab(rawURL string) (Repository, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &repository{url: rawURL, path: path, spec: &gitlabSpec{binding: "gitlab-binding"}}, nil
+	return &repository{url: rawURL, path: path, spec: &gitlabSpec{binding: "gitlab-push-binding"}}, nil
 }
 
 func proccessGitLabPath(parsedURL *url.URL) (string, error) {

--- a/pkg/pipelines/scm/gitlab_test.go
+++ b/pkg/pipelines/scm/gitlab_test.go
@@ -16,7 +16,7 @@ func TestCreateBindingForGitlab(t *testing.T) {
 	want := triggersv1.TriggerBinding{
 		TypeMeta: triggers.TriggerBindingTypeMeta,
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "gitlab-binding",
+			Name:      "gitlab-push-binding",
 			Namespace: "testns",
 		},
 		Spec: triggersv1.TriggerBindingSpec{
@@ -29,8 +29,8 @@ func TestCreateBindingForGitlab(t *testing.T) {
 		},
 	}
 	got, name := repo.CreateBinding("testns")
-	if name != "gitlab-binding" {
-		t.Fatalf("CreateBinding() returned a wrong binding: want %v got %v", "gitlab-binding", name)
+	if name != "gitlab-push-binding" {
+		t.Fatalf("CreateBinding() returned a wrong binding: want %v got %v", "gitlab-push-binding", name)
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("CreateBinding() failed:\n%s", diff)

--- a/pkg/pipelines/scm/interface.go
+++ b/pkg/pipelines/scm/interface.go
@@ -8,17 +8,11 @@ import (
 // implemented by repositories (Github,Gitlab,Bitbucket,etc)
 type Repository interface {
 
-	// Get Pull Request TriggerBinding name for this repository provider
-	PRBindingName() string
+	// Get TriggerBinding name for this repository provider
+	BindingName() string
 
-	// Get Push TriggerBinding name for this repository provider
-	PushBindingName() string
-
-	// Create a TriggerBinding for PullRequest hooks.
-	CreatePRBinding(namespace string) (triggersv1.TriggerBinding, string)
-
-	// Create a TriggerBinding for Push Request hooks
-	CreatePushBinding(namespace string) (triggersv1.TriggerBinding, string)
+	// Create a TriggerBinding for Push hooks.
+	CreateBinding(namespace string) (triggersv1.TriggerBinding, string)
 
 	// Create a CI eventlistener trigger
 	CreateCITrigger(name, secretName, secretNs, template string, bindings []string) triggersv1.EventListenerTrigger

--- a/pkg/pipelines/scm/utility.go
+++ b/pkg/pipelines/scm/utility.go
@@ -40,6 +40,9 @@ func createEventInterceptor(filter string, repoName string) *triggersv1.EventInt
 	return &triggersv1.EventInterceptor{
 		CEL: &triggersv1.CELInterceptor{
 			Filter: fmt.Sprintf(filter, repoName),
+			Overlays: []triggersv1.CELOverlay{
+				{Key: "ref", Expression: "split(body.ref,'/')[2]"},
+			},
 		},
 	}
 }

--- a/pkg/pipelines/scm/utility_test.go
+++ b/pkg/pipelines/scm/utility_test.go
@@ -33,6 +33,9 @@ func TestCreateEventInterceptor(t *testing.T) {
 	validEventInterceptor := triggersv1.EventInterceptor{
 		CEL: &triggersv1.CELInterceptor{
 			Filter: "sampleFilter sample",
+			Overlays: []triggersv1.CELOverlay{
+				{Key: "ref", Expression: "split(body.ref,'/')[2]"},
+			},
 		},
 	}
 	eventInterceptor := createEventInterceptor("sampleFilter %s", "sample")

--- a/pkg/pipelines/tekton_builder_test.go
+++ b/pkg/pipelines/tekton_builder_test.go
@@ -119,7 +119,7 @@ func TestGetPipelines(t *testing.T) {
 			&config.Pipelines{
 				Integration: &config.TemplateBinding{
 					Template: "app-ci-template",
-					Bindings: []string{"github-pr-binding"},
+					Bindings: []string{"github-binding"},
 				},
 			},
 		},
@@ -195,8 +195,9 @@ func fakeTriggers(t *testing.T, m *config.Manifest, gitOpsRepo string) []trigger
 		repo, err := scm.NewRepository(svc.SourceURL)
 		assertNoError(t, err)
 		pipelines := getPipelines(env, svc, repo)
-		devCITrigger := repo.CreateCITrigger(fmt.Sprintf("app-ci-build-from-pr-%s", svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, pipelines.Integration.Template, pipelines.Integration.Bindings)
-		triggers = append(triggers, devCITrigger)
+		devCITrigger := repo.CreateCITrigger(ciTriggerName(svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, pipelines.Integration.Template, pipelines.Integration.Bindings)
+		devCDTrigger := repo.CreateCDTrigger(cdTriggerName(svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, pipelines.Integration.Template, pipelines.Integration.Bindings)
+		triggers = append(triggers, devCITrigger, devCDTrigger)
 	}
 
 	return triggers

--- a/pkg/pipelines/tekton_builder_test.go
+++ b/pkg/pipelines/tekton_builder_test.go
@@ -119,7 +119,7 @@ func TestGetPipelines(t *testing.T) {
 			&config.Pipelines{
 				Integration: &config.TemplateBinding{
 					Template: "app-ci-template",
-					Bindings: []string{"github-binding"},
+					Bindings: []string{"github-push-binding"},
 				},
 			},
 		},


### PR DESCRIPTION


**What type of PR is this?**

> /kind feature

**What does this PR do / why we need it**:
* Since a push event is created for every PR, we can replace the pull_request hooks by push. This causes the pipelines to be triggered for every push event.
* This starts a new build when the PR is merged to the default branch.
* github-pr-binding is removed and github-push-binding is renamed to github-binding.
* Added CEL expression to extract the branch name from body.ref field of webhook payload.
* Update the existing unit tests

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-200

