### PR TITLE
Gitops issue 219-Adding argocd-ns flag to the bootstrap command

### DIFF
--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -106,6 +106,7 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "add a prefix to the environment names")
 	bootstrapCmd.Flags().StringVarP(&o.ImageRepo, "image-repo", "", "", "used to push built images")
 
+	bootstrapCmd.Flags().StringVarP(&o.ArgoCDNamespace, "argocd-ns", "", "argocd", "namespace in which the argocd operator is installed, to deploy the apps in argocd")
 	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "kube-system", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
 	bootstrapCmd.MarkFlagRequired("gitops-repo-url")
 	bootstrapCmd.MarkFlagRequired("service-repo-url")

--- a/pkg/pipelines/argocd/argocd.go
+++ b/pkg/pipelines/argocd/argocd.go
@@ -28,9 +28,8 @@ var (
 )
 
 const (
-	defaultServer   = "https://kubernetes.default.svc"
-	defaultProject  = "default"
-	ArgoCDNamespace = "argocd"
+	defaultServer  = "https://kubernetes.default.svc"
+	defaultProject = "default"
 )
 
 func Build(argoNS, repoURL string, m *config.Manifest) (res.Resources, error) {
@@ -65,7 +64,7 @@ type argocdBuilder struct {
 }
 
 func (b *argocdBuilder) Application(env *config.Environment, app *config.Application) error {
-	basePath := filepath.Join(config.PathForArgoCD())
+	basePath := filepath.Join(config.PathForArgoCD(b.argoNS))
 	argoFiles := res.Resources{}
 	filename := filepath.Join(basePath, env.Name+"-"+app.Name+"-app.yaml")
 
@@ -82,7 +81,7 @@ func argoCDConfigResources(argoCDConfig *config.ArgoCDConfig, files res.Resource
 	if argoCDConfig.Namespace == "" {
 		return nil
 	}
-	basePath := filepath.Join(config.PathForArgoCD())
+	basePath := filepath.Join(config.PathForArgoCD(argoCDConfig.Namespace))
 	filename := filepath.Join(basePath, "kustomization.yaml")
 	resourceNames := []string{}
 	for k := range files {

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -94,7 +94,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 
 	bootstrapped, err := createInitialFiles(
 		appFs, gitOpsRepo, o.Prefix, o.GitOpsWebhookSecret,
-		o.DockerConfigJSONFilename, o.SealedSecretsNamespace)
+		o.DockerConfigJSONFilename, o.SealedSecretsNamespace, o.ArgoCDNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -103,7 +103,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	appName := repoToAppName(repoName)
 	serviceName := repoName
 	secretName := secrets.MakeServiceWebhookSecretName(ns["dev"], serviceName)
-	envs, configEnv, err := bootstrapEnvironments(appRepo, o.Prefix, secretName, ns)
+	envs, configEnv, err := bootstrapEnvironments(appRepo, o.Prefix, secretName, o.ArgoCDNamespace, ns)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func bootstrapServiceDeployment(dev *config.Environment, appName string) (res.Re
 	return resources, nil
 }
 
-func bootstrapEnvironments(repo scm.Repository, prefix, secretName string, ns map[string]string) ([]*config.Environment, *config.Config, error) {
+func bootstrapEnvironments(repo scm.Repository, prefix, secretName, argoCDNamespace string, ns map[string]string) ([]*config.Environment, *config.Config, error) {
 	envs := []*config.Environment{}
 	var pipelinesConfig *config.PipelinesConfig
 	for k, v := range ns {
@@ -201,7 +201,8 @@ func bootstrapEnvironments(repo scm.Repository, prefix, secretName string, ns ma
 			envs = append(envs, env)
 		}
 	}
-	cfg := &config.Config{Pipelines: pipelinesConfig, ArgoCD: &config.ArgoCDConfig{Namespace: "argocd"}}
+
+	cfg := &config.Config{Pipelines: pipelinesConfig, ArgoCD: &config.ArgoCDConfig{Namespace: argoCDNamespace}}
 	return envs, cfg, nil
 }
 

--- a/pkg/pipelines/build.go
+++ b/pkg/pipelines/build.go
@@ -56,7 +56,7 @@ func buildResources(fs afero.Fs, o *BuildParameters, m *config.Manifest) (res.Re
 	}
 
 	resources = res.Merge(elFiles, resources)
-	argoApps, err := argocd.Build(argocd.ArgoCDNamespace, m.GitOpsURL, m)
+	argoApps, err := argocd.Build(m.Config.ArgoCD.Namespace, m.GitOpsURL, m)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pipelines/config/config.go
+++ b/pkg/pipelines/config/config.go
@@ -27,8 +27,8 @@ func PathForPipelines(pipeline *PipelinesConfig) string {
 }
 
 // PathForArgoCD returns the path for recording ArgoCD configuration.
-func PathForArgoCD() string {
-	return filepath.Join("config", "argocd")
+func PathForArgoCD(argocdNS string) string {
+	return filepath.Join("config", argocdNS)
 }
 
 // Manifest describes a set of environments, apps and services for deployment.

--- a/pkg/pipelines/config/validate.go
+++ b/pkg/pipelines/config/validate.go
@@ -198,7 +198,7 @@ func (vv *validateVisitor) validateConfig(manifest *Manifest) []error {
 	errs := []error{}
 	if manifest.Config != nil {
 		if manifest.Config.ArgoCD != nil {
-			if err := validateName(manifest.Config.ArgoCD.Namespace, yamlPath(PathForArgoCD())); err != nil {
+			if err := validateName(manifest.Config.ArgoCD.Namespace, yamlPath(PathForArgoCD(manifest.Config.ArgoCD.Namespace))); err != nil {
 				errs = append(errs, err)
 			}
 			vv.configNames[manifest.Config.ArgoCD.Namespace] = true

--- a/pkg/pipelines/dryrun/dryrun.go
+++ b/pkg/pipelines/dryrun/dryrun.go
@@ -8,7 +8,7 @@ import (
 
 const scriptTemplate = `#!/bin/sh
 is_argocd=false
-argo_path="config/argocd"
+argo_path="config/{{ .ARGOCDEnv }}"
 cicd_path="config/{{ .CICDEnv }}"
 cmd={{ .Cmd }}
 overall_exit=0
@@ -51,14 +51,15 @@ exit $overall_exit
 `
 
 type templateParam struct {
-	Cmd     string
-	CICDEnv string
+	Cmd       string
+	CICDEnv   string
+	ARGOCDEnv string
 }
 
 // MakeScript will create a script that can dry-run/apply
 // across all environments/applications
-func MakeScript(command, cicdEnv string) (string, error) {
-	params := templateParam{CICDEnv: cicdEnv, Cmd: command}
+func MakeScript(command, cicdEnv, argoCDEnv string) (string, error) {
+	params := templateParam{ARGOCDEnv: argoCDEnv, CICDEnv: cicdEnv, Cmd: command}
 	template, err := template.New("dryrun_script").Parse(scriptTemplate)
 	if err != nil {
 		return "", fmt.Errorf("unable to parse template: %v", err)

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -40,6 +40,7 @@ type InitOptions struct {
 	ImageRepo                string // This is where built images are pushed to.
 	OutputPath               string // Where to write the bootstrapped files to?
 	SealedSecretsNamespace   string // Where do we find the SealedSecrets service?
+	ArgoCDNamespace          string //where we find web address (host/port) of ArgoCD web console by looking up OpenShift Route
 }
 
 // PolicyRules to be bound to service account


### PR DESCRIPTION
**What type of PR is this?**
/kind design

**What does does this PR do / why we need it**:
Give an option to the user to install operator in different namespace other than argocd namespace

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-219

Co-authored by @gaganhegde 
