### PR TITLE
Make  "sealed-secrets" the default namspace and add "sealed-secrets-controller" flag

### DIFF
--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -106,7 +106,9 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "add a prefix to the environment names")
 	bootstrapCmd.Flags().StringVarP(&o.ImageRepo, "image-repo", "", "", "used to push built images")
 
-	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "kube-system", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsController, "sealed-secrets-controller", "", "sealedsecretcontroller-sealed-secrets", "Sealed Secrets Controller Name (default sealedsecretcontroller-sealed-secrets)")
+
 	bootstrapCmd.MarkFlagRequired("gitops-repo-url")
 	bootstrapCmd.MarkFlagRequired("service-repo-url")
 	bootstrapCmd.MarkFlagRequired("image-repo")

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -99,6 +99,8 @@ func NewCmdInit(name, fullName string) *cobra.Command {
 	initCmd.Flags().StringVar(&o.DockerConfigJSONFilename, "dockercfgjson", "~/.docker/config.json", "authenticates the image push to the desired image registry, path to config.json")
 	initCmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	initCmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "image repository in this form <registry>/<username>/<repository> or <project>/<app> for internal registry")
-	initCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "kube-system", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	initCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	initCmd.Flags().StringVarP(&o.SealedSecretsController, "sealed-secrets-controller", "", "sealedsecretcontroller-sealed-secrets", "Sealed Secrets Controller Name (default sealedsecretcontroller-sealed-secrets)")
+
 	return initCmd
 }

--- a/pkg/odo/cli/pipelines/service/add.go
+++ b/pkg/odo/cli/pipelines/service/add.go
@@ -75,7 +75,8 @@ func newCmdAdd(name, fullName string) *cobra.Command {
 	cmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "used to push built images")
 	cmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	cmd.Flags().StringVar(&o.PipelinesFilePath, "pipelines-file", "pipelines.yaml", "path to pipelines file")
-	cmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "kube-system", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	cmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	cmd.Flags().StringVarP(&o.SealedSecretsController, "sealed-secrets-controller", "", "sealedsecretcontroller-sealed-secrets", "Sealed Secrets Controller Name (default sealedsecretcontroller-sealed-secrets)")
 
 	// required flags
 	_ = cmd.MarkFlagRequired("service-name")

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -94,7 +94,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 
 	bootstrapped, err := createInitialFiles(
 		appFs, gitOpsRepo, o.Prefix, o.GitOpsWebhookSecret,
-		o.DockerConfigJSONFilename, o.SealedSecretsNamespace)
+		o.DockerConfigJSONFilename, o.SealedSecretsNamespace, o.SealedSecretsController)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	hookSecret, err := secrets.CreateSealedSecret(
 		meta.NamespacedName(ns["cicd"], secretName),
 		o.ServiceWebhookSecret,
-		eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace)
+		eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace, o.SealedSecretsController)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate GitHub Webhook Secret: %v", err)
 	}

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -26,7 +26,7 @@ func TestBootstrapManifest(t *testing.T) {
 		secrets.DefaultPublicKeyFunc = f
 	}(secrets.DefaultPublicKeyFunc)
 
-	secrets.DefaultPublicKeyFunc = func(ns string) (*rsa.PublicKey, error) {
+	secrets.DefaultPublicKeyFunc = func(ns, controller string) (*rsa.PublicKey, error) {
 		key, err := rsa.GenerateKey(rand.Reader, 1024)
 		if err != nil {
 			t.Fatalf("failed to generate a private RSA key: %s", err)
@@ -49,7 +49,7 @@ func TestBootstrapManifest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hookSecret, err := secrets.CreateSealedSecret(meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api"), "456", eventlisteners.WebhookSecretKey, "test-ns")
+	hookSecret, err := secrets.CreateSealedSecret(meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api"), "456", eventlisteners.WebhookSecretKey, "test-ns", "controller")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -39,7 +39,8 @@ type InitOptions struct {
 	InternalRegistryHostname string // This is the internal registry hostname used for pushing images.
 	ImageRepo                string // This is where built images are pushed to.
 	OutputPath               string // Where to write the bootstrapped files to?
-	SealedSecretsNamespace   string // Where do we find the SealedSecrets service?
+	SealedSecretsNamespace   string // SealedSecret Controller Namespace
+	SealedSecretsController  string // SealedSecret Controller Name
 }
 
 // PolicyRules to be bound to service account
@@ -124,7 +125,7 @@ func Init(o *InitOptions, fs afero.Fs) error {
 		return err
 	}
 
-	outputs, err := createInitialFiles(fs, gitOpsRepo, o.Prefix, o.GitOpsWebhookSecret, o.DockerConfigJSONFilename, o.SealedSecretsNamespace)
+	outputs, err := createInitialFiles(fs, gitOpsRepo, o.Prefix, o.GitOpsWebhookSecret, o.DockerConfigJSONFilename, o.SealedSecretsNamespace, o.SealedSecretsController)
 	if err != nil {
 		return err
 	}
@@ -132,14 +133,14 @@ func Init(o *InitOptions, fs afero.Fs) error {
 	return err
 }
 
-func createInitialFiles(fs afero.Fs, repo scm.Repository, prefix, gitOpsWebhookSecret, dockerConfigPath, sealedSecretsNS string) (res.Resources, error) {
+func createInitialFiles(fs afero.Fs, repo scm.Repository, prefix, gitOpsWebhookSecret, dockerConfigPath, sealedSecretsNS, sealedSecretsController string) (res.Resources, error) {
 	cicd := &config.PipelinesConfig{Name: prefix + "cicd"}
 	pipelineConfig := &config.Config{Pipelines: cicd}
 	pipelines := createManifest(repo.URL(), pipelineConfig)
 	initialFiles := res.Resources{
 		pipelinesFile: pipelines,
 	}
-	resources, err := createCICDResources(fs, repo, cicd, gitOpsWebhookSecret, dockerConfigPath, sealedSecretsNS)
+	resources, err := createCICDResources(fs, repo, cicd, gitOpsWebhookSecret, dockerConfigPath, sealedSecretsNS, sealedSecretsController)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +159,7 @@ func createInitialFiles(fs afero.Fs, repo scm.Repository, prefix, gitOpsWebhookS
 
 // createDockerSecret creates a secret that allows pushing images to upstream
 // repositories.
-func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS, sealedSecretsNS string) (*ssv1alpha1.SealedSecret, error) {
+func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS, sealedSecretsNS, sealedSecretsController string) (*ssv1alpha1.SealedSecret, error) {
 	if dockerConfigJSONFilename == "" {
 		return nil, errors.New("failed to generate path to file: --dockerconfigjson flag is not provided")
 	}
@@ -172,7 +173,7 @@ func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS, sealedS
 	}
 	defer f.Close()
 
-	dockerSecret, err := secrets.CreateSealedDockerConfigSecret(meta.NamespacedName(secretNS, dockerSecretName), f, sealedSecretsNS)
+	dockerSecret, err := secrets.CreateSealedDockerConfigSecret(meta.NamespacedName(secretNS, dockerSecretName), f, sealedSecretsNS, sealedSecretsController)
 	if err != nil {
 		return nil, err
 	}
@@ -181,13 +182,13 @@ func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS, sealedS
 }
 
 // createCICDResources creates resources assocated to pipelines.
-func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *config.PipelinesConfig, gitOpsWebhookSecret, dockerConfigJSONPath, sealedSecretsNS string) (res.Resources, error) {
+func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *config.PipelinesConfig, gitOpsWebhookSecret, dockerConfigJSONPath, sealedSecretsNS, sealedSecretsController string) (res.Resources, error) {
 	cicdNamespace := pipelineConfig.Name
 	// key: path of the resource
 	// value: YAML content of the resource
 	outputs := map[string]interface{}{}
 	githubSecret, err := secrets.CreateSealedSecret(meta.NamespacedName(cicdNamespace, eventlisteners.GitOpsWebhookSecret),
-		gitOpsWebhookSecret, eventlisteners.WebhookSecretKey, sealedSecretsNS)
+		gitOpsWebhookSecret, eventlisteners.WebhookSecretKey, sealedSecretsNS, sealedSecretsController)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate GitHub Webhook Secret: %v", err)
 	}
@@ -199,7 +200,7 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 	sa := roles.CreateServiceAccount(meta.NamespacedName(cicdNamespace, saName))
 
 	if dockerConfigJSONPath != "" {
-		dockerSecret, err := createDockerSecret(fs, dockerConfigJSONPath, cicdNamespace, sealedSecretsNS)
+		dockerSecret, err := createDockerSecret(fs, dockerConfigJSONPath, cicdNamespace, sealedSecretsNS, sealedSecretsController)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pipelines/init_test.go
+++ b/pkg/pipelines/init_test.go
@@ -36,7 +36,7 @@ func TestInitialFiles(t *testing.T) {
 	fakeFs := ioutils.NewMapFilesystem()
 	repo, err := scm.NewRepository(gitOpsURL)
 	assertNoError(t, err)
-	got, err := createInitialFiles(fakeFs, repo, prefix, gitOpsWebhook, "", "test-ns")
+	got, err := createInitialFiles(fakeFs, repo, prefix, gitOpsWebhook, "", "test-ns", "controller")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func TestInitialFiles(t *testing.T) {
 	want := res.Resources{
 		pipelinesFile: createManifest(gitOpsURL, &config.Config{Pipelines: testpipelineConfig}),
 	}
-	resources, err := createCICDResources(fakeFs, repo, testpipelineConfig, gitOpsWebhook, "", "test-ns")
+	resources, err := createCICDResources(fakeFs, repo, testpipelineConfig, gitOpsWebhook, "", "test-ns", "controller")
 	if err != nil {
 		t.Fatalf("CreatePipelineResources() failed due to :%s\n", err)
 	}

--- a/pkg/pipelines/secrets/secrets.go
+++ b/pkg/pipelines/secrets/secrets.go
@@ -28,7 +28,8 @@ var (
 // DefaultPublicKeyFunc is the func used to get the key from Bitnami.
 var DefaultPublicKeyFunc = getClusterPublicKey
 
-type PublicKeyFunc func(string) (*rsa.PublicKey, error)
+// PublicKeyFunc returns public key given two arguments: controller NS and controller name
+type PublicKeyFunc func(string, string) (*rsa.PublicKey, error)
 
 // MakeServiceWebhookSecretName common method to create service webhook secret name
 func MakeServiceWebhookSecretName(envName, serviceName string) string {
@@ -36,27 +37,27 @@ func MakeServiceWebhookSecretName(envName, serviceName string) string {
 }
 
 // CreateSealedDockerConfigSecret creates a SealedSecret with the given name and reader
-func CreateSealedDockerConfigSecret(name types.NamespacedName, in io.Reader, controllerNS string) (*ssv1alpha1.SealedSecret, error) {
+func CreateSealedDockerConfigSecret(name types.NamespacedName, in io.Reader, controllerNS, controllerName string) (*ssv1alpha1.SealedSecret, error) {
 	secret, err := createDockerConfigSecret(name, in)
 	if err != nil {
 		return nil, err
 	}
 
-	return seal(secret, DefaultPublicKeyFunc, controllerNS)
+	return seal(secret, DefaultPublicKeyFunc, controllerNS, controllerName)
 }
 
 // CreateSealedSecret creates a SealedSecret with the provided name and body/data and type
-func CreateSealedSecret(name types.NamespacedName, data, secretKey, controllerNS string) (*ssv1alpha1.SealedSecret, error) {
+func CreateSealedSecret(name types.NamespacedName, data, secretKey, controllerNS, controllerName string) (*ssv1alpha1.SealedSecret, error) {
 	secret, err := createOpaqueSecret(name, data, secretKey)
 	if err != nil {
 		return nil, err
 	}
 
-	return seal(secret, DefaultPublicKeyFunc, controllerNS)
+	return seal(secret, DefaultPublicKeyFunc, controllerNS, controllerName)
 }
 
 // Returns a sealed secret
-func seal(secret *corev1.Secret, pubKey PublicKeyFunc, controllerNS string) (*ssv1alpha1.SealedSecret, error) {
+func seal(secret *corev1.Secret, pubKey PublicKeyFunc, controllerNS, controllerName string) (*ssv1alpha1.SealedSecret, error) {
 	// Strip read-only server-side ObjectMeta (if present)
 	secret.SetSelfLink("")
 	secret.SetUID("")
@@ -66,7 +67,7 @@ func seal(secret *corev1.Secret, pubKey PublicKeyFunc, controllerNS string) (*ss
 	secret.SetDeletionTimestamp(nil)
 	secret.DeletionGracePeriodSeconds = nil
 
-	key, err := pubKey(controllerNS)
+	key, err := pubKey(controllerNS, controllerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get public key from cluster (is sealed-secrets installed?): %v", err)
 	}
@@ -83,13 +84,13 @@ func seal(secret *corev1.Secret, pubKey PublicKeyFunc, controllerNS string) (*ss
 
 // Retrieves a public key from sealed-secrets-controller, by finding the
 // controller in the provided namespace and fetching its key.
-func getClusterPublicKey(ns string) (*rsa.PublicKey, error) {
+func getClusterPublicKey(ns, controller string) (*rsa.PublicKey, error) {
 	client, err := getRESTClient()
 	if err != nil {
 		return nil, err
 	}
 
-	f, err := openCertCluster(client, ns)
+	f, err := openCertCluster(client, ns, controller)
 	if err != nil {
 		return nil, err
 	}
@@ -98,10 +99,10 @@ func getClusterPublicKey(ns string) (*rsa.PublicKey, error) {
 }
 
 // Returns a reader of public key from sealed-secrets-controller
-func openCertCluster(c clientv1.CoreV1Interface, ns string) (io.ReadCloser, error) {
+func openCertCluster(c clientv1.CoreV1Interface, ns, controller string) (io.ReadCloser, error) {
 	f, err := c.
 		Services(ns).
-		ProxyGet("http", "sealedsecretcontroller-sealed-secrets", "", "/v1/cert.pem", nil).
+		ProxyGet("http", controller, "", "/v1/cert.pem", nil).
 		Stream()
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch certificate: %v", err)

--- a/pkg/pipelines/secrets/secrets_test.go
+++ b/pkg/pipelines/secrets/secrets_test.go
@@ -203,7 +203,7 @@ func TestSeal(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			result, err := seal(&tc.secret, makeTestCertFunc("test-ns"), "test-ns")
+			result, err := seal(&tc.secret, makeTestCertFunc("test-ns"), "test-ns", "controller")
 			if err != nil {
 				if diff := cmp.Diff(tc.errMessage, err.Error()); diff != "" {
 					t.Errorf("Unexpected error \n%s", diff)
@@ -241,7 +241,7 @@ func TestSeal(t *testing.T) {
 }
 
 func makeTestCertFunc(testNS string) PublicKeyFunc {
-	return func(ns string) (*rsa.PublicKey, error) {
+	return func(ns, controller string) (*rsa.PublicKey, error) {
 		if ns != testNS {
 			return nil, fmt.Errorf("failed to generate secret from controller in incorrect namespace, got %#v, want %#v", ns, testNS)
 		}

--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -29,6 +29,8 @@ type AddServiceOptions struct {
 	ServiceName              string
 	WebhookSecret            string
 	SealedSecretsNamespace   string // Where do we find the SealedSecrets service?
+	SealedSecretsController  string // Sealed Secrets Controller name
+
 }
 
 func AddService(p *AddServiceOptions, fs afero.Fs) error {
@@ -84,7 +86,7 @@ func serviceResources(m *config.Manifest, fs afero.Fs, o *AddServiceOptions) (re
 		secretName := secrets.MakeServiceWebhookSecretName(o.EnvName, svc.Name)
 		hookSecret, err := secrets.CreateSealedSecret(
 			meta.NamespacedName(cfg.Name, secretName), o.WebhookSecret,
-			eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace)
+			eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace, o.SealedSecretsController)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pipelines/service_test.go
+++ b/pkg/pipelines/service_test.go
@@ -31,7 +31,7 @@ func TestServiceResourcesWithCICD(t *testing.T) {
 		meta.NamespacedName(
 			"cicd", "webhook-secret-test-dev-test"),
 		"123",
-		eventlisteners.WebhookSecretKey, "test-ns")
+		eventlisteners.WebhookSecretKey, "test-ns", "controller")
 	assertNoError(t, err)
 
 	want := res.Resources{
@@ -481,7 +481,7 @@ func TestCreateSvcImageBinding(t *testing.T) {
 
 func stubDefaultPublicKeyFunc(t *testing.T) func() {
 	origDefaultPublicKeyFunc := secrets.DefaultPublicKeyFunc
-	secrets.DefaultPublicKeyFunc = func(string) (*rsa.PublicKey, error) {
+	secrets.DefaultPublicKeyFunc = func(string, string) (*rsa.PublicKey, error) {
 		key, err := rsa.GenerateKey(rand.Reader, 1024)
 		if err != nil {
 			t.Fatalf("failed to generate a private RSA key: %s", err)

--- a/pkg/pipelines/statustracker/deployment.go
+++ b/pkg/pipelines/statustracker/deployment.go
@@ -21,7 +21,7 @@ const (
 	commitStatusAppLabel = "commit-status-tracker-operator"
 )
 
-type secretSealer = func(types.NamespacedName, string, string, string) (*ssv1alpha1.SealedSecret, error)
+type secretSealer = func(types.NamespacedName, string, string, string, string) (*ssv1alpha1.SealedSecret, error)
 
 var defaultSecretSealer secretSealer = secrets.CreateSealedSecret
 
@@ -98,11 +98,11 @@ func createStatusTrackerDeployment(ns string) *appsv1.Deployment {
 
 // Resources returns a list of newly created resources that are required start
 // the status-tracker service.
-func Resources(ns, token, sealedSecretsNS string) ([]interface{}, error) {
+func Resources(ns, token, sealedSecretsNS, sealedSecretController string) ([]interface{}, error) {
 	name := meta.NamespacedName(ns, operatorName)
 	sa := roles.CreateServiceAccount(name)
 
-	githubAuth, err := defaultSecretSealer(meta.NamespacedName(ns, "commit-status-tracker-git-secret"), token, "token", sealedSecretsNS)
+	githubAuth, err := defaultSecretSealer(meta.NamespacedName(ns, "commit-status-tracker-git-secret"), token, "token", sealedSecretsNS, sealedSecretController)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate Status Tracker Secret: %v", err)
 	}

--- a/pkg/pipelines/statustracker/deployment_test.go
+++ b/pkg/pipelines/statustracker/deployment_test.go
@@ -78,12 +78,13 @@ func TestResource(t *testing.T) {
 	}(defaultSecretSealer)
 
 	testSecret := &ssv1alpha1.SealedSecret{}
-	defaultSecretSealer = func(ns types.NamespacedName, data, secretKey, _ string) (*ssv1alpha1.SealedSecret, error) {
+	defaultSecretSealer = func(ns types.NamespacedName, data, secretKey, _, _ string) (*ssv1alpha1.SealedSecret, error) {
 		return testSecret, nil
 	}
 
 	ns := "my-test-ns"
-	res, err := Resources(ns, "test-token", "sealed-secrets-ns")
+	res, err := Resources(ns, "test-token", "sealed-secrets-ns", "sealled-secrets-controller")
+
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR makes the following changes.

* make "sealed-secrets"  the default value for the --sealed-secrets-ns flag as the it is the default namespace where Sealed Secret Operator is installed.
*add --sealed-secrets-controller flag and default it to "sealedsecretcontroller-sealed-secrets" which is the controller name installed by SS operator.  

Having the above flags allows users  to specify manually installed SS controller in case SS operator is cannot be used.   Currently, SS Operator cannot be used in OpenShift due to this bug.  https://github.com/helm/charts/pull/22369/files.   Manually installed SS controller can be specified by the following flags.
--sealed-secrets-ns kube-system
--sealed-secrets-controller sealed-secrets-controller

Use to the SS operator's controller, above flags are not specified as by default SS operator's controller is used.

/kind bug







