### PR TITLE
--sealed-secrets-ns gets default value "sealed-secrets" and --sealed-secrets-svc flag

### DIFF
--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -110,8 +110,8 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "add a prefix to the environment names")
 	bootstrapCmd.Flags().StringVarP(&o.ImageRepo, "image-repo", "", "", "used to push built images")
 
-	bootstrapCmd.Flags().StringVar(&o.SealedSecretsServices.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
-	bootstrapCmd.Flags().StringVar(&o.SealedSecretsServices.Name, "sealed-secrets-svc", "sealedsecretservices-sealed-secrets", "name of the Sealed Secrets services that encrypts secrets")
+	bootstrapCmd.Flags().StringVar(&o.SealedSecretsService.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	bootstrapCmd.Flags().StringVar(&o.SealedSecretsService.Name, "sealed-secrets-svc", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets services that encrypts secrets")
 
 	bootstrapCmd.MarkFlagRequired("gitops-repo-url")
 	bootstrapCmd.MarkFlagRequired("service-repo-url")

--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -110,8 +110,9 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "add a prefix to the environment names")
 	bootstrapCmd.Flags().StringVarP(&o.ImageRepo, "image-repo", "", "", "used to push built images")
 
-	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
-	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsController, "sealed-secrets-controller", "", "sealedsecretcontroller-sealed-secrets", "SealedSecrets Controller name (default: sealedsecretcontroller-sealed-secrets)")
+	bootstrapCmd.Flags().StringVar(&o.SealedSecretsController.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	bootstrapCmd.Flags().StringVar(&o.SealedSecretsController.Name, "sealed-secrets-controller", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets controller that encrypts secrets")
+
 	bootstrapCmd.MarkFlagRequired("gitops-repo-url")
 	bootstrapCmd.MarkFlagRequired("service-repo-url")
 	bootstrapCmd.MarkFlagRequired("image-repo")

--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -110,7 +110,8 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "add a prefix to the environment names")
 	bootstrapCmd.Flags().StringVarP(&o.ImageRepo, "image-repo", "", "", "used to push built images")
 
-	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "kube-system", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	bootstrapCmd.Flags().StringVarP(&o.SealedSecretsController, "sealed-secrets-controller", "", "sealedsecretcontroller-sealed-secrets", "SealedSecrets Controller name (default: sealedsecretcontroller-sealed-secrets)")
 	bootstrapCmd.MarkFlagRequired("gitops-repo-url")
 	bootstrapCmd.MarkFlagRequired("service-repo-url")
 	bootstrapCmd.MarkFlagRequired("image-repo")

--- a/pkg/odo/cli/pipelines/bootstrap.go
+++ b/pkg/odo/cli/pipelines/bootstrap.go
@@ -110,8 +110,8 @@ func NewCmdBootstrap(name, fullName string) *cobra.Command {
 	bootstrapCmd.Flags().StringVarP(&o.Prefix, "prefix", "p", "", "add a prefix to the environment names")
 	bootstrapCmd.Flags().StringVarP(&o.ImageRepo, "image-repo", "", "", "used to push built images")
 
-	bootstrapCmd.Flags().StringVar(&o.SealedSecretsController.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
-	bootstrapCmd.Flags().StringVar(&o.SealedSecretsController.Name, "sealed-secrets-controller", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets controller that encrypts secrets")
+	bootstrapCmd.Flags().StringVar(&o.SealedSecretsServices.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	bootstrapCmd.Flags().StringVar(&o.SealedSecretsServices.Name, "sealed-secrets-svc", "sealedsecretservices-sealed-secrets", "name of the Sealed Secrets services that encrypts secrets")
 
 	bootstrapCmd.MarkFlagRequired("gitops-repo-url")
 	bootstrapCmd.MarkFlagRequired("service-repo-url")

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -101,8 +101,8 @@ func NewCmdInit(name, fullName string) *cobra.Command {
 	initCmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	initCmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "image repository in this form <registry>/<username>/<repository> or <project>/<app> for internal registry")
 
-	initCmd.Flags().StringVar(&o.SealedSecretsController.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
-	initCmd.Flags().StringVar(&o.SealedSecretsController.Name, "sealed-secrets-controller", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets controller that encrypts secrets")
+	initCmd.Flags().StringVar(&o.SealedSecretsServices.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	initCmd.Flags().StringVar(&o.SealedSecretsServices.Name, "sealed-secrets-svc", "sealedsecretServices-sealed-secrets", "name of the Sealed Secrets Services that encrypts secrets")
 
 	return initCmd
 }

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -101,8 +101,8 @@ func NewCmdInit(name, fullName string) *cobra.Command {
 	initCmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	initCmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "image repository in this form <registry>/<username>/<repository> or <project>/<app> for internal registry")
 
-	initCmd.Flags().StringVar(&o.SealedSecretsServices.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
-	initCmd.Flags().StringVar(&o.SealedSecretsServices.Name, "sealed-secrets-svc", "sealedsecretServices-sealed-secrets", "name of the Sealed Secrets Services that encrypts secrets")
+	initCmd.Flags().StringVar(&o.SealedSecretsService.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	initCmd.Flags().StringVar(&o.SealedSecretsService.Name, "sealed-secrets-svc", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets Services that encrypts secrets")
 
 	return initCmd
 }

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/odo/pkg/odo/genericclioptions"
 	"github.com/openshift/odo/pkg/pipelines"
 	"github.com/openshift/odo/pkg/pipelines/ioutils"
+
 	"github.com/spf13/cobra"
 
 	ktemplates "k8s.io/kubectl/pkg/util/templates"
@@ -99,8 +100,9 @@ func NewCmdInit(name, fullName string) *cobra.Command {
 	initCmd.Flags().StringVar(&o.DockerConfigJSONFilename, "dockercfgjson", "~/.docker/config.json", "authenticates the image push to the desired image registry, path to config.json")
 	initCmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	initCmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "image repository in this form <registry>/<username>/<repository> or <project>/<app> for internal registry")
-	initCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
-	initCmd.Flags().StringVarP(&o.SealedSecretsController, "sealed-secrets-controller", "", "sealedsecretcontroller-sealed-secrets", "SealedSecrets Controller name (default: sealedsecretcontroller-sealed-secrets)")
+
+	initCmd.Flags().StringVar(&o.SealedSecretsController.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	initCmd.Flags().StringVar(&o.SealedSecretsController.Name, "sealed-secrets-controller", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets controller that encrypts secrets")
 
 	return initCmd
 }

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -99,6 +99,8 @@ func NewCmdInit(name, fullName string) *cobra.Command {
 	initCmd.Flags().StringVar(&o.DockerConfigJSONFilename, "dockercfgjson", "~/.docker/config.json", "authenticates the image push to the desired image registry, path to config.json")
 	initCmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	initCmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "image repository in this form <registry>/<username>/<repository> or <project>/<app> for internal registry")
-	initCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "kube-system", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	initCmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	initCmd.Flags().StringVarP(&o.SealedSecretsController, "sealed-secrets-controller", "", "sealedsecretcontroller-sealed-secrets", "SealedSecrets Controller name (default: sealedsecretcontroller-sealed-secrets)")
+
 	return initCmd
 }

--- a/pkg/odo/cli/pipelines/service/add.go
+++ b/pkg/odo/cli/pipelines/service/add.go
@@ -76,8 +76,8 @@ func newCmdAdd(name, fullName string) *cobra.Command {
 	cmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	cmd.Flags().StringVar(&o.PipelinesFilePath, "pipelines-file", "pipelines.yaml", "path to pipelines file")
 
-	cmd.Flags().StringVar(&o.SealedSecretsController.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
-	cmd.Flags().StringVar(&o.SealedSecretsController.Name, "sealed-secrets-controller", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets controller that encrypts secrets")
+	cmd.Flags().StringVar(&o.SealedSecretsServices.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	cmd.Flags().StringVar(&o.SealedSecretsServices.Name, "sealed-secrets-svc", "sealedsecretservices-sealed-secrets", "name of the Sealed Secrets services that encrypts secrets")
 
 	// required flags
 	_ = cmd.MarkFlagRequired("service-name")

--- a/pkg/odo/cli/pipelines/service/add.go
+++ b/pkg/odo/cli/pipelines/service/add.go
@@ -76,8 +76,8 @@ func newCmdAdd(name, fullName string) *cobra.Command {
 	cmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	cmd.Flags().StringVar(&o.PipelinesFilePath, "pipelines-file", "pipelines.yaml", "path to pipelines file")
 
-	cmd.Flags().StringVar(&o.SealedSecretsServices.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
-	cmd.Flags().StringVar(&o.SealedSecretsServices.Name, "sealed-secrets-svc", "sealedsecretservices-sealed-secrets", "name of the Sealed Secrets services that encrypts secrets")
+	cmd.Flags().StringVar(&o.SealedSecretsService.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	cmd.Flags().StringVar(&o.SealedSecretsService.Name, "sealed-secrets-svc", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets services that encrypts secrets")
 
 	// required flags
 	_ = cmd.MarkFlagRequired("service-name")

--- a/pkg/odo/cli/pipelines/service/add.go
+++ b/pkg/odo/cli/pipelines/service/add.go
@@ -75,8 +75,9 @@ func newCmdAdd(name, fullName string) *cobra.Command {
 	cmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "used to push built images")
 	cmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	cmd.Flags().StringVar(&o.PipelinesFilePath, "pipelines-file", "pipelines.yaml", "path to pipelines file")
-	cmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
-	cmd.Flags().StringVarP(&o.SealedSecretsController, "sealed-secrets-controller", "", "sealedsecretcontroller-sealed-secrets", "SealedSecrets Controller name (default: sealedsecretcontroller-sealed-secrets)")
+
+	cmd.Flags().StringVar(&o.SealedSecretsController.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	cmd.Flags().StringVar(&o.SealedSecretsController.Name, "sealed-secrets-controller", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets controller that encrypts secrets")
 
 	// required flags
 	_ = cmd.MarkFlagRequired("service-name")

--- a/pkg/odo/cli/pipelines/service/add.go
+++ b/pkg/odo/cli/pipelines/service/add.go
@@ -75,7 +75,8 @@ func newCmdAdd(name, fullName string) *cobra.Command {
 	cmd.Flags().StringVar(&o.ImageRepo, "image-repo", "", "used to push built images")
 	cmd.Flags().StringVar(&o.InternalRegistryHostname, "internal-registry-hostname", "image-registry.openshift-image-registry.svc:5000", "internal image registry hostname")
 	cmd.Flags().StringVar(&o.PipelinesFilePath, "pipelines-file", "pipelines.yaml", "path to pipelines file")
-	cmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "kube-system", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	cmd.Flags().StringVarP(&o.SealedSecretsNamespace, "sealed-secrets-ns", "", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
+	cmd.Flags().StringVarP(&o.SealedSecretsController, "sealed-secrets-controller", "", "sealedsecretcontroller-sealed-secrets", "SealedSecrets Controller name (default: sealedsecretcontroller-sealed-secrets)")
 
 	// required flags
 	_ = cmd.MarkFlagRequired("service-name")

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -117,7 +117,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	}
 	hookSecret, err := secrets.CreateSealedSecret(
 		meta.NamespacedName(ns["cicd"], secretName),
-		o.SealedSecretsServices,
+		o.SealedSecretsService,
 		o.ServiceWebhookSecret,
 		eventlisteners.WebhookSecretKey)
 	if err != nil {

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -118,7 +118,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	hookSecret, err := secrets.CreateSealedSecret(
 		meta.NamespacedName(ns["cicd"], secretName),
 		o.ServiceWebhookSecret,
-		eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace)
+		eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace, o.SealedSecretsController)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate GitHub Webhook Secret: %v", err)
 	}

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -117,7 +117,7 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	}
 	hookSecret, err := secrets.CreateSealedSecret(
 		meta.NamespacedName(ns["cicd"], secretName),
-		o.SealedSecretsController,
+		o.SealedSecretsServices,
 		o.ServiceWebhookSecret,
 		eventlisteners.WebhookSecretKey)
 	if err != nil {

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -117,8 +117,9 @@ func bootstrapResources(o *BootstrapOptions, appFs afero.Fs) (res.Resources, err
 	}
 	hookSecret, err := secrets.CreateSealedSecret(
 		meta.NamespacedName(ns["cicd"], secretName),
+		o.SealedSecretsController,
 		o.ServiceWebhookSecret,
-		eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace, o.SealedSecretsController)
+		eventlisteners.WebhookSecretKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate GitHub Webhook Secret: %v", err)
 	}

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -26,7 +26,7 @@ func TestBootstrapManifest(t *testing.T) {
 		secrets.DefaultPublicKeyFunc = f
 	}(secrets.DefaultPublicKeyFunc)
 
-	secrets.DefaultPublicKeyFunc = func(ns string) (*rsa.PublicKey, error) {
+	secrets.DefaultPublicKeyFunc = func(ns, controller string) (*rsa.PublicKey, error) {
 		key, err := rsa.GenerateKey(rand.Reader, 1024)
 		if err != nil {
 			t.Fatalf("failed to generate a private RSA key: %s", err)
@@ -49,7 +49,7 @@ func TestBootstrapManifest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hookSecret, err := secrets.CreateSealedSecret(meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api"), "456", eventlisteners.WebhookSecretKey, "test-ns")
+	hookSecret, err := secrets.CreateSealedSecret(meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api"), "456", eventlisteners.WebhookSecretKey, "test-ns", "controller")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/odo/pkg/pipelines/meta"
 	res "github.com/openshift/odo/pkg/pipelines/resources"
 	"github.com/openshift/odo/pkg/pipelines/secrets"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -26,7 +27,7 @@ func TestBootstrapManifest(t *testing.T) {
 		secrets.DefaultPublicKeyFunc = f
 	}(secrets.DefaultPublicKeyFunc)
 
-	secrets.DefaultPublicKeyFunc = func(ns, controller string) (*rsa.PublicKey, error) {
+	secrets.DefaultPublicKeyFunc = func(controller types.NamespacedName) (*rsa.PublicKey, error) {
 		key, err := rsa.GenerateKey(rand.Reader, 1024)
 		if err != nil {
 			t.Fatalf("failed to generate a private RSA key: %s", err)
@@ -49,7 +50,7 @@ func TestBootstrapManifest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hookSecret, err := secrets.CreateSealedSecret(meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api"), "456", eventlisteners.WebhookSecretKey, "test-ns", "controller")
+	hookSecret, err := secrets.CreateSealedSecret(meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api"), meta.NamespacedName("test-ns", "controller"), "456", eventlisteners.WebhookSecretKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -27,7 +27,7 @@ func TestBootstrapManifest(t *testing.T) {
 		secrets.DefaultPublicKeyFunc = f
 	}(secrets.DefaultPublicKeyFunc)
 
-	secrets.DefaultPublicKeyFunc = func(controller types.NamespacedName) (*rsa.PublicKey, error) {
+	secrets.DefaultPublicKeyFunc = func(service types.NamespacedName) (*rsa.PublicKey, error) {
 		key, err := rsa.GenerateKey(rand.Reader, 1024)
 		if err != nil {
 			t.Fatalf("failed to generate a private RSA key: %s", err)
@@ -50,7 +50,7 @@ func TestBootstrapManifest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hookSecret, err := secrets.CreateSealedSecret(meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api"), meta.NamespacedName("test-ns", "controller"), "456", eventlisteners.WebhookSecretKey)
+	hookSecret, err := secrets.CreateSealedSecret(meta.NamespacedName("tst-cicd", "webhook-secret-tst-dev-http-api"), meta.NamespacedName("test-ns", "service"), "456", eventlisteners.WebhookSecretKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/afero"
 
 	v1rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealed-secrets/v1alpha1"
 )
@@ -36,11 +37,10 @@ type InitOptions struct {
 	GitOpsWebhookSecret      string // This is the secret for authenticating hooks from your GitOps repo.
 	Prefix                   string
 	DockerConfigJSONFilename string
-	InternalRegistryHostname string // This is the internal registry hostname used for pushing images.
-	ImageRepo                string // This is where built images are pushed to.
-	OutputPath               string // Where to write the bootstrapped files to?
-	SealedSecretsNamespace   string // Where do we find the SealedSecrets service?
-	SealedSecretsController  string // Sealed Secret Controller name
+	InternalRegistryHostname string               // This is the internal registry hostname used for pushing images.
+	ImageRepo                string               // This is where built images are pushed to.
+	OutputPath               string               // Where to write the bootstrapped files to?
+	SealedSecretsController  types.NamespacedName // SealedSecrets controller name
 }
 
 // PolicyRules to be bound to service account
@@ -159,7 +159,7 @@ func createInitialFiles(fs afero.Fs, repo scm.Repository, o *InitOptions) (res.R
 
 // createDockerSecret creates a secret that allows pushing images to upstream
 // repositories.
-func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS, sealedSecretsNS, sealedSecretsController string) (*ssv1alpha1.SealedSecret, error) {
+func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS string, sealedSecretsController types.NamespacedName) (*ssv1alpha1.SealedSecret, error) {
 	if dockerConfigJSONFilename == "" {
 		return nil, errors.New("failed to generate path to file: --dockerconfigjson flag is not provided")
 	}
@@ -173,7 +173,7 @@ func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS, sealedS
 	}
 	defer f.Close()
 
-	dockerSecret, err := secrets.CreateSealedDockerConfigSecret(meta.NamespacedName(secretNS, dockerSecretName), f, sealedSecretsNS, sealedSecretsController)
+	dockerSecret, err := secrets.CreateSealedDockerConfigSecret(meta.NamespacedName(secretNS, dockerSecretName), sealedSecretsController, f)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 	// value: YAML content of the resource
 	outputs := map[string]interface{}{}
 	githubSecret, err := secrets.CreateSealedSecret(meta.NamespacedName(cicdNamespace, eventlisteners.GitOpsWebhookSecret),
-		o.GitOpsWebhookSecret, eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace, o.SealedSecretsController)
+		o.SealedSecretsController, o.GitOpsWebhookSecret, eventlisteners.WebhookSecretKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate GitHub Webhook Secret: %v", err)
 	}
@@ -201,7 +201,7 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 
 	if o.DockerConfigJSONFilename != "" {
 		dockerSecret, err := createDockerSecret(fs, o.DockerConfigJSONFilename, cicdNamespace,
-			o.SealedSecretsNamespace, o.SealedSecretsController)
+			o.SealedSecretsController)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -40,7 +40,7 @@ type InitOptions struct {
 	InternalRegistryHostname string               // This is the internal registry hostname used for pushing images.
 	ImageRepo                string               // This is where built images are pushed to.
 	OutputPath               string               // Where to write the bootstrapped files to?
-	SealedSecretsController  types.NamespacedName // SealedSecrets controller name
+	SealedSecretsServices    types.NamespacedName // SealedSecrets Services name
 }
 
 // PolicyRules to be bound to service account
@@ -159,7 +159,7 @@ func createInitialFiles(fs afero.Fs, repo scm.Repository, o *InitOptions) (res.R
 
 // createDockerSecret creates a secret that allows pushing images to upstream
 // repositories.
-func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS string, sealedSecretsController types.NamespacedName) (*ssv1alpha1.SealedSecret, error) {
+func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS string, SealedSecretsServices types.NamespacedName) (*ssv1alpha1.SealedSecret, error) {
 	if dockerConfigJSONFilename == "" {
 		return nil, errors.New("failed to generate path to file: --dockerconfigjson flag is not provided")
 	}
@@ -173,7 +173,7 @@ func createDockerSecret(fs afero.Fs, dockerConfigJSONFilename, secretNS string, 
 	}
 	defer f.Close()
 
-	dockerSecret, err := secrets.CreateSealedDockerConfigSecret(meta.NamespacedName(secretNS, dockerSecretName), sealedSecretsController, f)
+	dockerSecret, err := secrets.CreateSealedDockerConfigSecret(meta.NamespacedName(secretNS, dockerSecretName), SealedSecretsServices, f)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 	// value: YAML content of the resource
 	outputs := map[string]interface{}{}
 	githubSecret, err := secrets.CreateSealedSecret(meta.NamespacedName(cicdNamespace, eventlisteners.GitOpsWebhookSecret),
-		o.SealedSecretsController, o.GitOpsWebhookSecret, eventlisteners.WebhookSecretKey)
+		o.SealedSecretsServices, o.GitOpsWebhookSecret, eventlisteners.WebhookSecretKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate GitHub Webhook Secret: %v", err)
 	}
@@ -201,7 +201,7 @@ func createCICDResources(fs afero.Fs, repo scm.Repository, pipelineConfig *confi
 
 	if o.DockerConfigJSONFilename != "" {
 		dockerSecret, err := createDockerSecret(fs, o.DockerConfigJSONFilename, cicdNamespace,
-			o.SealedSecretsController)
+			o.SealedSecretsServices)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pipelines/secrets/secrets.go
+++ b/pkg/pipelines/secrets/secrets.go
@@ -28,7 +28,8 @@ var (
 // DefaultPublicKeyFunc is the func used to get the key from Bitnami.
 var DefaultPublicKeyFunc = getClusterPublicKey
 
-type PublicKeyFunc func(string) (*rsa.PublicKey, error)
+// PublicKeyFunc retruns a public key given a namespace and controller name
+type PublicKeyFunc func(string, string) (*rsa.PublicKey, error)
 
 // MakeServiceWebhookSecretName common method to create service webhook secret name
 func MakeServiceWebhookSecretName(envName, serviceName string) string {
@@ -36,27 +37,27 @@ func MakeServiceWebhookSecretName(envName, serviceName string) string {
 }
 
 // CreateSealedDockerConfigSecret creates a SealedSecret with the given name and reader
-func CreateSealedDockerConfigSecret(name types.NamespacedName, in io.Reader, controllerNS string) (*ssv1alpha1.SealedSecret, error) {
+func CreateSealedDockerConfigSecret(name types.NamespacedName, in io.Reader, controllerNS, controllerName string) (*ssv1alpha1.SealedSecret, error) {
 	secret, err := createDockerConfigSecret(name, in)
 	if err != nil {
 		return nil, err
 	}
 
-	return seal(secret, DefaultPublicKeyFunc, controllerNS)
+	return seal(secret, DefaultPublicKeyFunc, controllerNS, controllerName)
 }
 
 // CreateSealedSecret creates a SealedSecret with the provided name and body/data and type
-func CreateSealedSecret(name types.NamespacedName, data, secretKey, controllerNS string) (*ssv1alpha1.SealedSecret, error) {
+func CreateSealedSecret(name types.NamespacedName, data, secretKey, controllerNS, controllerName string) (*ssv1alpha1.SealedSecret, error) {
 	secret, err := createOpaqueSecret(name, data, secretKey)
 	if err != nil {
 		return nil, err
 	}
 
-	return seal(secret, DefaultPublicKeyFunc, controllerNS)
+	return seal(secret, DefaultPublicKeyFunc, controllerNS, controllerName)
 }
 
 // Returns a sealed secret
-func seal(secret *corev1.Secret, pubKey PublicKeyFunc, controllerNS string) (*ssv1alpha1.SealedSecret, error) {
+func seal(secret *corev1.Secret, pubKey PublicKeyFunc, controllerNS, controllerName string) (*ssv1alpha1.SealedSecret, error) {
 	// Strip read-only server-side ObjectMeta (if present)
 	secret.SetSelfLink("")
 	secret.SetUID("")
@@ -66,7 +67,7 @@ func seal(secret *corev1.Secret, pubKey PublicKeyFunc, controllerNS string) (*ss
 	secret.SetDeletionTimestamp(nil)
 	secret.DeletionGracePeriodSeconds = nil
 
-	key, err := pubKey(controllerNS)
+	key, err := pubKey(controllerNS, controllerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get public key from cluster (is sealed-secrets installed?): %v", err)
 	}
@@ -83,13 +84,13 @@ func seal(secret *corev1.Secret, pubKey PublicKeyFunc, controllerNS string) (*ss
 
 // Retrieves a public key from sealed-secrets-controller, by finding the
 // controller in the provided namespace and fetching its key.
-func getClusterPublicKey(ns string) (*rsa.PublicKey, error) {
+func getClusterPublicKey(ns, controller string) (*rsa.PublicKey, error) {
 	client, err := getRESTClient()
 	if err != nil {
 		return nil, err
 	}
 
-	f, err := openCertCluster(client, ns)
+	f, err := openCertCluster(client, ns, controller)
 	if err != nil {
 		return nil, err
 	}
@@ -98,10 +99,10 @@ func getClusterPublicKey(ns string) (*rsa.PublicKey, error) {
 }
 
 // Returns a reader of public key from sealed-secrets-controller
-func openCertCluster(c clientv1.CoreV1Interface, ns string) (io.ReadCloser, error) {
+func openCertCluster(c clientv1.CoreV1Interface, ns, controller string) (io.ReadCloser, error) {
 	f, err := c.
 		Services(ns).
-		ProxyGet("http", "sealedsecretcontroller-sealed-secrets", "", "/v1/cert.pem", nil).
+		ProxyGet("http", controller, "", "/v1/cert.pem", nil).
 		Stream()
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch certificate: %v", err)

--- a/pkg/pipelines/secrets/secrets_test.go
+++ b/pkg/pipelines/secrets/secrets_test.go
@@ -203,7 +203,7 @@ func TestSeal(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			result, err := seal(&tc.secret, makeTestCertFunc("test-ns"), "test-ns")
+			result, err := seal(&tc.secret, makeTestCertFunc("test-ns"), "test-ns", "controller")
 			if err != nil {
 				if diff := cmp.Diff(tc.errMessage, err.Error()); diff != "" {
 					t.Errorf("Unexpected error \n%s", diff)
@@ -241,7 +241,7 @@ func TestSeal(t *testing.T) {
 }
 
 func makeTestCertFunc(testNS string) PublicKeyFunc {
-	return func(ns string) (*rsa.PublicKey, error) {
+	return func(ns, controller string) (*rsa.PublicKey, error) {
 		if ns != testNS {
 			return nil, fmt.Errorf("failed to generate secret from controller in incorrect namespace, got %#v, want %#v", ns, testNS)
 		}

--- a/pkg/pipelines/secrets/secrets_test.go
+++ b/pkg/pipelines/secrets/secrets_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/odo/pkg/pipelines/meta"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openshift/odo/tests/helper"
 )
@@ -203,7 +204,7 @@ func TestSeal(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			result, err := seal(&tc.secret, makeTestCertFunc("test-ns"), "test-ns", "controller")
+			result, err := seal(&tc.secret, makeTestCertFunc(meta.NamespacedName("test-ns", "controller")), meta.NamespacedName("test-ns", "controller"))
 			if err != nil {
 				if diff := cmp.Diff(tc.errMessage, err.Error()); diff != "" {
 					t.Errorf("Unexpected error \n%s", diff)
@@ -240,10 +241,10 @@ func TestSeal(t *testing.T) {
 	}
 }
 
-func makeTestCertFunc(testNS string) PublicKeyFunc {
-	return func(ns, controller string) (*rsa.PublicKey, error) {
-		if ns != testNS {
-			return nil, fmt.Errorf("failed to generate secret from controller in incorrect namespace, got %#v, want %#v", ns, testNS)
+func makeTestCertFunc(testController types.NamespacedName) PublicKeyFunc {
+	return func(controller types.NamespacedName) (*rsa.PublicKey, error) {
+		if testController.Namespace != controller.Namespace {
+			return nil, fmt.Errorf("failed to generate secret from controller in incorrect namespace, got %#v, want %#v", controller.Namespace, testController.Namespace)
 		}
 		return parseKey(strings.NewReader(testCert))
 	}

--- a/pkg/pipelines/secrets/secrets_test.go
+++ b/pkg/pipelines/secrets/secrets_test.go
@@ -204,7 +204,7 @@ func TestSeal(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			result, err := seal(&tc.secret, makeTestCertFunc(meta.NamespacedName("test-ns", "controller")), meta.NamespacedName("test-ns", "controller"))
+			result, err := seal(&tc.secret, makeTestCertFunc(meta.NamespacedName("test-ns", "service")), meta.NamespacedName("test-ns", "service"))
 			if err != nil {
 				if diff := cmp.Diff(tc.errMessage, err.Error()); diff != "" {
 					t.Errorf("Unexpected error \n%s", diff)
@@ -241,10 +241,10 @@ func TestSeal(t *testing.T) {
 	}
 }
 
-func makeTestCertFunc(testController types.NamespacedName) PublicKeyFunc {
-	return func(controller types.NamespacedName) (*rsa.PublicKey, error) {
-		if testController.Namespace != controller.Namespace {
-			return nil, fmt.Errorf("failed to generate secret from controller in incorrect namespace, got %#v, want %#v", controller.Namespace, testController.Namespace)
+func makeTestCertFunc(testservice types.NamespacedName) PublicKeyFunc {
+	return func(service types.NamespacedName) (*rsa.PublicKey, error) {
+		if testservice.Namespace != service.Namespace {
+			return nil, fmt.Errorf("failed to generate secret from service in incorrect namespace, got %#v, want %#v", service.Namespace, testservice.Namespace)
 		}
 		return parseKey(strings.NewReader(testCert))
 	}

--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -29,6 +29,7 @@ type AddServiceOptions struct {
 	ServiceName              string
 	WebhookSecret            string
 	SealedSecretsNamespace   string // Where do we find the SealedSecrets service?
+	SealedSecretsController  string // SealedSecrets controller name
 }
 
 func AddService(p *AddServiceOptions, fs afero.Fs) error {
@@ -84,7 +85,7 @@ func serviceResources(m *config.Manifest, fs afero.Fs, o *AddServiceOptions) (re
 		secretName := secrets.MakeServiceWebhookSecretName(o.EnvName, svc.Name)
 		hookSecret, err := secrets.CreateSealedSecret(
 			meta.NamespacedName(cfg.Name, secretName), o.WebhookSecret,
-			eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace)
+			eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace, o.SealedSecretsController)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -29,7 +29,7 @@ type AddServiceOptions struct {
 	PipelinesFilePath        string
 	ServiceName              string
 	WebhookSecret            string
-	SealedSecretsServices    types.NamespacedName // SealedSecrets controller name
+	SealedSecretsService     types.NamespacedName // SealedSecrets service name
 }
 
 func AddService(p *AddServiceOptions, fs afero.Fs) error {
@@ -84,7 +84,7 @@ func serviceResources(m *config.Manifest, fs afero.Fs, o *AddServiceOptions) (re
 	if cfg != nil {
 		secretName := secrets.MakeServiceWebhookSecretName(o.EnvName, svc.Name)
 		hookSecret, err := secrets.CreateSealedSecret(
-			meta.NamespacedName(cfg.Name, secretName), o.SealedSecretsServices, o.WebhookSecret,
+			meta.NamespacedName(cfg.Name, secretName), o.SealedSecretsService, o.WebhookSecret,
 			eventlisteners.WebhookSecretKey)
 		if err != nil {
 			return nil, err

--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -29,7 +29,7 @@ type AddServiceOptions struct {
 	PipelinesFilePath        string
 	ServiceName              string
 	WebhookSecret            string
-	SealedSecretsController  types.NamespacedName // SealedSecrets controller name
+	SealedSecretsServices    types.NamespacedName // SealedSecrets controller name
 }
 
 func AddService(p *AddServiceOptions, fs afero.Fs) error {
@@ -84,7 +84,7 @@ func serviceResources(m *config.Manifest, fs afero.Fs, o *AddServiceOptions) (re
 	if cfg != nil {
 		secretName := secrets.MakeServiceWebhookSecretName(o.EnvName, svc.Name)
 		hookSecret, err := secrets.CreateSealedSecret(
-			meta.NamespacedName(cfg.Name, secretName), o.SealedSecretsController, o.WebhookSecret,
+			meta.NamespacedName(cfg.Name, secretName), o.SealedSecretsServices, o.WebhookSecret,
 			eventlisteners.WebhookSecretKey)
 		if err != nil {
 			return nil, err

--- a/pkg/pipelines/service.go
+++ b/pkg/pipelines/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/odo/pkg/pipelines/triggers"
 	"github.com/openshift/odo/pkg/pipelines/yaml"
 	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // AddServiceOptions control how new services are added to the configuration.
@@ -28,8 +29,7 @@ type AddServiceOptions struct {
 	PipelinesFilePath        string
 	ServiceName              string
 	WebhookSecret            string
-	SealedSecretsNamespace   string // Where do we find the SealedSecrets service?
-	SealedSecretsController  string // SealedSecrets controller name
+	SealedSecretsController  types.NamespacedName // SealedSecrets controller name
 }
 
 func AddService(p *AddServiceOptions, fs afero.Fs) error {
@@ -84,8 +84,8 @@ func serviceResources(m *config.Manifest, fs afero.Fs, o *AddServiceOptions) (re
 	if cfg != nil {
 		secretName := secrets.MakeServiceWebhookSecretName(o.EnvName, svc.Name)
 		hookSecret, err := secrets.CreateSealedSecret(
-			meta.NamespacedName(cfg.Name, secretName), o.WebhookSecret,
-			eventlisteners.WebhookSecretKey, o.SealedSecretsNamespace, o.SealedSecretsController)
+			meta.NamespacedName(cfg.Name, secretName), o.SealedSecretsController, o.WebhookSecret,
+			eventlisteners.WebhookSecretKey)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pipelines/service_test.go
+++ b/pkg/pipelines/service_test.go
@@ -31,7 +31,7 @@ func TestServiceResourcesWithCICD(t *testing.T) {
 		meta.NamespacedName(
 			"cicd", "webhook-secret-test-dev-test"),
 		"123",
-		eventlisteners.WebhookSecretKey, "test-ns")
+		eventlisteners.WebhookSecretKey, "test-ns", "controller")
 	assertNoError(t, err)
 
 	want := res.Resources{
@@ -477,7 +477,7 @@ func TestCreateSvcImageBinding(t *testing.T) {
 
 func stubDefaultPublicKeyFunc(t *testing.T) func() {
 	origDefaultPublicKeyFunc := secrets.DefaultPublicKeyFunc
-	secrets.DefaultPublicKeyFunc = func(string) (*rsa.PublicKey, error) {
+	secrets.DefaultPublicKeyFunc = func(string, string) (*rsa.PublicKey, error) {
 		key, err := rsa.GenerateKey(rand.Reader, 1024)
 		if err != nil {
 			t.Fatalf("failed to generate a private RSA key: %s", err)

--- a/pkg/pipelines/service_test.go
+++ b/pkg/pipelines/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/odo/pkg/pipelines/eventlisteners"
 	"github.com/spf13/afero"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/odo/pkg/pipelines/ioutils"
@@ -30,8 +31,9 @@ func TestServiceResourcesWithCICD(t *testing.T) {
 	hookSecret, err := secrets.CreateSealedSecret(
 		meta.NamespacedName(
 			"cicd", "webhook-secret-test-dev-test"),
+		meta.NamespacedName("test-ns", "controller"),
 		"123",
-		eventlisteners.WebhookSecretKey, "test-ns", "controller")
+		eventlisteners.WebhookSecretKey)
 	assertNoError(t, err)
 
 	want := res.Resources{
@@ -477,7 +479,7 @@ func TestCreateSvcImageBinding(t *testing.T) {
 
 func stubDefaultPublicKeyFunc(t *testing.T) func() {
 	origDefaultPublicKeyFunc := secrets.DefaultPublicKeyFunc
-	secrets.DefaultPublicKeyFunc = func(string, string) (*rsa.PublicKey, error) {
+	secrets.DefaultPublicKeyFunc = func(types.NamespacedName) (*rsa.PublicKey, error) {
 		key, err := rsa.GenerateKey(rand.Reader, 1024)
 		if err != nil {
 			t.Fatalf("failed to generate a private RSA key: %s", err)

--- a/pkg/pipelines/service_test.go
+++ b/pkg/pipelines/service_test.go
@@ -31,7 +31,7 @@ func TestServiceResourcesWithCICD(t *testing.T) {
 	hookSecret, err := secrets.CreateSealedSecret(
 		meta.NamespacedName(
 			"cicd", "webhook-secret-test-dev-test"),
-		meta.NamespacedName("test-ns", "controller"),
+		meta.NamespacedName("test-ns", "service"),
 		"123",
 		eventlisteners.WebhookSecretKey)
 	assertNoError(t, err)

--- a/pkg/pipelines/statustracker/deployment.go
+++ b/pkg/pipelines/statustracker/deployment.go
@@ -21,7 +21,7 @@ const (
 	commitStatusAppLabel = "commit-status-tracker-operator"
 )
 
-type secretSealer = func(types.NamespacedName, string, string, string) (*ssv1alpha1.SealedSecret, error)
+type secretSealer = func(types.NamespacedName, string, string, string, string) (*ssv1alpha1.SealedSecret, error)
 
 var defaultSecretSealer secretSealer = secrets.CreateSealedSecret
 
@@ -98,11 +98,11 @@ func createStatusTrackerDeployment(ns string) *appsv1.Deployment {
 
 // Resources returns a list of newly created resources that are required start
 // the status-tracker service.
-func Resources(ns, token, sealedSecretsNS string) ([]interface{}, error) {
+func Resources(ns, token, sealedSecretsNS, sealedSecretsController string) ([]interface{}, error) {
 	name := meta.NamespacedName(ns, operatorName)
 	sa := roles.CreateServiceAccount(name)
 
-	githubAuth, err := defaultSecretSealer(meta.NamespacedName(ns, "commit-status-tracker-git-secret"), token, "token", sealedSecretsNS)
+	githubAuth, err := defaultSecretSealer(meta.NamespacedName(ns, "commit-status-tracker-git-secret"), token, "token", sealedSecretsNS, sealedSecretsController)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate Status Tracker Secret: %v", err)
 	}

--- a/pkg/pipelines/statustracker/deployment.go
+++ b/pkg/pipelines/statustracker/deployment.go
@@ -98,11 +98,11 @@ func createStatusTrackerDeployment(ns string) *appsv1.Deployment {
 
 // Resources returns a list of newly created resources that are required start
 // the status-tracker service.
-func Resources(ns, token string, sealedSecretsController types.NamespacedName) ([]interface{}, error) {
+func Resources(ns, token string, sealedSecretsservice types.NamespacedName) ([]interface{}, error) {
 	name := meta.NamespacedName(ns, operatorName)
 	sa := roles.CreateServiceAccount(name)
 
-	githubAuth, err := defaultSecretSealer(meta.NamespacedName(ns, "commit-status-tracker-git-secret"), sealedSecretsController, token, "token")
+	githubAuth, err := defaultSecretSealer(meta.NamespacedName(ns, "commit-status-tracker-git-secret"), sealedSecretsservice, token, "token")
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate Status Tracker Secret: %v", err)
 	}

--- a/pkg/pipelines/statustracker/deployment.go
+++ b/pkg/pipelines/statustracker/deployment.go
@@ -21,7 +21,7 @@ const (
 	commitStatusAppLabel = "commit-status-tracker-operator"
 )
 
-type secretSealer = func(types.NamespacedName, string, string, string, string) (*ssv1alpha1.SealedSecret, error)
+type secretSealer = func(types.NamespacedName, types.NamespacedName, string, string) (*ssv1alpha1.SealedSecret, error)
 
 var defaultSecretSealer secretSealer = secrets.CreateSealedSecret
 
@@ -98,11 +98,11 @@ func createStatusTrackerDeployment(ns string) *appsv1.Deployment {
 
 // Resources returns a list of newly created resources that are required start
 // the status-tracker service.
-func Resources(ns, token, sealedSecretsNS, sealedSecretsController string) ([]interface{}, error) {
+func Resources(ns, token string, sealedSecretsController types.NamespacedName) ([]interface{}, error) {
 	name := meta.NamespacedName(ns, operatorName)
 	sa := roles.CreateServiceAccount(name)
 
-	githubAuth, err := defaultSecretSealer(meta.NamespacedName(ns, "commit-status-tracker-git-secret"), token, "token", sealedSecretsNS, sealedSecretsController)
+	githubAuth, err := defaultSecretSealer(meta.NamespacedName(ns, "commit-status-tracker-git-secret"), sealedSecretsController, token, "token")
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate Status Tracker Secret: %v", err)
 	}

--- a/pkg/pipelines/statustracker/deployment_test.go
+++ b/pkg/pipelines/statustracker/deployment_test.go
@@ -83,7 +83,7 @@ func TestResource(t *testing.T) {
 	}
 
 	ns := "my-test-ns"
-	res, err := Resources(ns, "test-token", meta.NamespacedName("sealed-secrets-ns", "sealed-secrets-controller"))
+	res, err := Resources(ns, "test-token", meta.NamespacedName("sealed-secrets-ns", "sealed-secrets-svc"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pipelines/statustracker/deployment_test.go
+++ b/pkg/pipelines/statustracker/deployment_test.go
@@ -78,12 +78,12 @@ func TestResource(t *testing.T) {
 	}(defaultSecretSealer)
 
 	testSecret := &ssv1alpha1.SealedSecret{}
-	defaultSecretSealer = func(ns types.NamespacedName, data, secretKey, _, _ string) (*ssv1alpha1.SealedSecret, error) {
+	defaultSecretSealer = func(ns, _ types.NamespacedName, data, secretKey string) (*ssv1alpha1.SealedSecret, error) {
 		return testSecret, nil
 	}
 
 	ns := "my-test-ns"
-	res, err := Resources(ns, "test-token", "sealed-secrets-ns", "sealed-secrets-controller")
+	res, err := Resources(ns, "test-token", meta.NamespacedName("sealed-secrets-ns", "sealed-secrets-controller"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pipelines/statustracker/deployment_test.go
+++ b/pkg/pipelines/statustracker/deployment_test.go
@@ -78,12 +78,12 @@ func TestResource(t *testing.T) {
 	}(defaultSecretSealer)
 
 	testSecret := &ssv1alpha1.SealedSecret{}
-	defaultSecretSealer = func(ns types.NamespacedName, data, secretKey, _ string) (*ssv1alpha1.SealedSecret, error) {
+	defaultSecretSealer = func(ns types.NamespacedName, data, secretKey, _, _ string) (*ssv1alpha1.SealedSecret, error) {
 		return testSecret, nil
 	}
 
 	ns := "my-test-ns"
-	res, err := Resources(ns, "test-token", "sealed-secrets-ns")
+	res, err := Resources(ns, "test-token", "sealed-secrets-ns", "sealed-secrets-controller")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR makes changes to bootstrap, init, and "service add" commands.

* the default value for sealed-secrets-ns is set to "sealed-secrets".    The new SealedSecrets Operator (v0.0.2) uses "sealed-secrets" as the default namespace.  Aligning the defaults would allow use to use SealedSecrets Operator's controller without further configuration.
* added new flag --sealed-secrets-controller which has the default value to match the controller name installed by SealedSecretts Operator.   The default value is "sealed-secrets-controller"

The above flags enable manually installed Sealed Secrets to work in case the operator controllers is not functional  by providing the following flags:
--sealed-secrets-ns kube-system
--sealed-secrets-controller sealed-secrets-controller.

To use operator's controller, the above flags are not needed as the default is to work with operator.

Currently, SealedSecrets Operator (v.0.0.2) has a blocking problem https://github.com/helm/charts/pull/22369/files and can't work in OpenShift.

/kind bug
