### PR TITLE
Remove unncessary "pipelines" folder from resources paths for internal registry resources.

### DIFF
--- a/pkg/pipelines/imagerepo/imagerepo.go
+++ b/pkg/pipelines/imagerepo/imagerepo.go
@@ -67,7 +67,7 @@ func CreateInternalRegistryResources(cfg *config.PipelinesConfig, sa *corev1.Ser
 	filenames := []string{}
 
 	filename := filepath.Join("01-namespaces", fmt.Sprintf("%s.yaml", namespace))
-	namespacePath := filepath.Join(config.PathForPipelines(cfg), "base", "pipelines", filename)
+	namespacePath := filepath.Join(config.PathForPipelines(cfg), "base", filename)
 	resources[namespacePath] = namespaces.Create(namespace, gitOpsRepoURL)
 	filenames = append(filenames, filename)
 
@@ -78,6 +78,6 @@ func CreateInternalRegistryResources(cfg *config.PipelinesConfig, sa *corev1.Ser
 func createInternalRegistryRoleBinding(cfg *config.PipelinesConfig, ns string, sa *corev1.ServiceAccount) (string, res.Resources) {
 	roleBindingName := fmt.Sprintf("internal-registry-%s-binding", ns)
 	roleBindingFilname := filepath.Join("02-rolebindings", fmt.Sprintf("%s.yaml", roleBindingName))
-	roleBindingPath := filepath.Join(config.PathForPipelines(cfg), "base", "pipelines", roleBindingFilname)
+	roleBindingPath := filepath.Join(config.PathForPipelines(cfg), "base", roleBindingFilname)
 	return roleBindingFilname, res.Resources{roleBindingPath: roles.CreateRoleBinding(meta.NamespacedName(ns, roleBindingName), sa, "ClusterRole", "edit")}
 }

--- a/pkg/pipelines/imagerepo/imagerepo_test.go
+++ b/pkg/pipelines/imagerepo/imagerepo_test.go
@@ -19,7 +19,7 @@ func TestCreateInternalRegistryRoleBinding(t *testing.T) {
 	sa := roles.CreateServiceAccount(meta.NamespacedName("test-cicd", "pipeline"))
 	gotFilename, got := createInternalRegistryRoleBinding(pipelinesConfig, "new-proj", sa)
 
-	want := res.Resources{"config/test-cicd/base/pipelines/02-rolebindings/internal-registry-new-proj-binding.yaml": &v1rbac.RoleBinding{
+	want := res.Resources{"config/test-cicd/base/02-rolebindings/internal-registry-new-proj-binding.yaml": &v1rbac.RoleBinding{
 		TypeMeta:   meta.TypeMeta("RoleBinding", "rbac.authorization.k8s.io/v1"),
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("new-proj", "internal-registry-new-proj-binding")),
 		Subjects:   []v1rbac.Subject{{Kind: sa.Kind, Name: sa.Name, Namespace: sa.Namespace}},


### PR DESCRIPTION
https://github.com/rhd-gitops-example/odo/pull/134  to remove unwanted directory from config removed "pipelines" folder but it missed internal registry resources.   This PR is to remove "pipelines" folder path component for internal registry resources (namespace and role binding)

/kind bug

