### PR TITLE
Add Author, Commit and timestamp labels to the image.

### DIFF
--- a/pkg/pipelines/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines/pipelines.go
@@ -26,7 +26,6 @@ func CreateAppCIPipeline(name types.NamespacedName) *pipelinev1.Pipeline {
 				createParamSpec("COMMIT_SHA", "string"),
 				createParamSpec("TLSVERIFY", "string"),
 				createParamSpec("BUILD_EXTRA_ARGS", "string"),
-
 				createParamSpec("GIT_REF", "string"),
 				createParamSpec("COMMIT_DATE", "string"),
 				createParamSpec("COMMIT_AUTHOR", "string"),

--- a/pkg/pipelines/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines/pipelines.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/openshift/odo/pkg/pipelines/meta"
+	"github.com/openshift/odo/pkg/pipelines/triggers"
 )
 
 var (
@@ -55,7 +56,7 @@ func createBuildImageTask(name string) pipelinev1.PipelineTask {
 		},
 		Params: []pipelinev1.Param{
 			createTaskParam("TLSVERIFY", "$(params.TLSVERIFY)"),
-			createTaskParam("BUILD_EXTRA_ARGS", "--label=io.openshift.build.commit.id=$(params.COMMIT_SHA) --label=io.openshift.build.commit.ref=$(params.GIT_REF) --label=io.openshift.build.commit.date=$(params.COMMIT_DATE) --label=io.openshift.build.commit.author=$(params.COMMIT_AUTHOR) --label=io.openshift.build.commit.message=$(params.COMMIT_MESSAGE)"),
+			createTaskParam("BUILD_EXTRA_ARGS", "--label="+triggers.GitCommitID+"='$(params.COMMIT_SHA)' --label="+triggers.GitRef+"='$(params.GIT_REF)' --label="+triggers.GitCommitDate+"='$(params.COMMIT_DATE)' --label="+triggers.GitCommitAuthor+"='$(params.COMMIT_AUTHOR)' --label="+triggers.GitCommitMessage+"='$(params.COMMIT_MESSAGE)'"),
 		},
 	}
 

--- a/pkg/pipelines/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines/pipelines.go
@@ -21,6 +21,13 @@ func CreateAppCIPipeline(name types.NamespacedName) *pipelinev1.Pipeline {
 				createParamSpec("REPO", "string"),
 				createParamSpec("COMMIT_SHA", "string"),
 				createParamSpec("TLSVERIFY", "string"),
+				createParamSpec("BUILD_EXTRA_ARGS", "string"),
+
+				createParamSpec("GIT_REF", "string"),
+				createParamSpec("COMMIT_DATE", "string"),
+				createParamSpec("COMMIT_AUTHOR", "string"),
+				createParamSpec("COMMIT_MESSAGE", "string"),
+				createParamSpec("GIT_REPO", "string"),
 			},
 			Resources: []pipelinev1.PipelineDeclaredResource{
 				createPipelineDeclaredResource("source-repo", "git"),
@@ -48,6 +55,7 @@ func createBuildImageTask(name string) pipelinev1.PipelineTask {
 		},
 		Params: []pipelinev1.Param{
 			createTaskParam("TLSVERIFY", "$(params.TLSVERIFY)"),
+			createTaskParam("BUILD_EXTRA_ARGS", "--label=io.openshift.build.commit.id=$(params.COMMIT_SHA) --label=io.openshift.build.commit.ref=$(params.GIT_REF) --label=io.openshift.build.commit.date=$(params.COMMIT_DATE) --label=io.openshift.build.commit.author=$(params.COMMIT_AUTHOR) --label=io.openshift.build.commit.message=$(params.COMMIT_MESSAGE)"),
 		},
 	}
 

--- a/pkg/pipelines/scm/github.go
+++ b/pkg/pipelines/scm/github.go
@@ -53,7 +53,7 @@ func (r *githubSpec) pushBindingParams() []triggersv1.Param {
 		createBindingParam("gitrepositoryurl", "$(body.repository.clone_url)"),
 		createBindingParam("fullname", "$(body.repository.full_name)"),
 		createBindingParam(triggers.GitCommitDate, "$(body.head_commit.timestamp)"),
-		createBindingParam(triggers.GitCommitMessage, "$(body.head_commit.message"),
+		createBindingParam(triggers.GitCommitMessage, "$(body.head_commit.message)"),
 		createBindingParam(triggers.GitCommitAuthor, "$(body.head_commit.author.name)"),
 	}
 }

--- a/pkg/pipelines/scm/github.go
+++ b/pkg/pipelines/scm/github.go
@@ -47,8 +47,8 @@ func (r *githubSpec) pushBindingName() string {
 
 func (r *githubSpec) pushBindingParams() []triggersv1.Param {
 	return []triggersv1.Param{
-		createBindingParam("gitref", "$(body.ref)"),
-		createBindingParam("gitsha", "$(body.head_commit.id)"),
+		createBindingParam("io.openshift.build.commit.ref", "$(body.ref)"),
+		createBindingParam("io.openshift.build.commit.id", "$(body.head_commit.id)"),
 		createBindingParam("gitrepositoryurl", "$(body.repository.clone_url)"),
 		createBindingParam("fullname", "$(body.repository.full_name)"),
 		createBindingParam("commitdate", "$(body.head_commit.timestamp)"),

--- a/pkg/pipelines/scm/github.go
+++ b/pkg/pipelines/scm/github.go
@@ -51,6 +51,9 @@ func (r *githubSpec) pushBindingParams() []triggersv1.Param {
 		createBindingParam("gitsha", "$(body.head_commit.id)"),
 		createBindingParam("gitrepositoryurl", "$(body.repository.clone_url)"),
 		createBindingParam("fullname", "$(body.repository.full_name)"),
+		createBindingParam("commitdate", "$(body.head_commit.timestamp)"),
+		createBindingParam("commitmessage", "$(body.head_commit.message"),
+		createBindingParam("commitauthor", "$(body.head_commit.author.name)"),
 	}
 }
 

--- a/pkg/pipelines/scm/github.go
+++ b/pkg/pipelines/scm/github.go
@@ -48,10 +48,10 @@ func (r *githubSpec) pushBindingName() string {
 
 func (r *githubSpec) pushBindingParams() []triggersv1.Param {
 	return []triggersv1.Param{
-		createBindingParam(triggers.GitRef, "$(body.ref)"),
-		createBindingParam(triggers.GitCommitID, "$(body.head_commit.id)"),
 		createBindingParam("gitrepositoryurl", "$(body.repository.clone_url)"),
 		createBindingParam("fullname", "$(body.repository.full_name)"),
+		createBindingParam(triggers.GitRef, "$(body.ref)"),
+		createBindingParam(triggers.GitCommitID, "$(body.head_commit.id)"),
 		createBindingParam(triggers.GitCommitDate, "$(body.head_commit.timestamp)"),
 		createBindingParam(triggers.GitCommitMessage, "$(body.head_commit.message)"),
 		createBindingParam(triggers.GitCommitAuthor, "$(body.head_commit.author.name)"),

--- a/pkg/pipelines/scm/github.go
+++ b/pkg/pipelines/scm/github.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/openshift/odo/pkg/pipelines/triggers"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 )
 
@@ -47,13 +48,13 @@ func (r *githubSpec) pushBindingName() string {
 
 func (r *githubSpec) pushBindingParams() []triggersv1.Param {
 	return []triggersv1.Param{
-		createBindingParam("io.openshift.build.commit.ref", "$(body.ref)"),
-		createBindingParam("io.openshift.build.commit.id", "$(body.head_commit.id)"),
+		createBindingParam(triggers.GitRef, "$(body.ref)"),
+		createBindingParam(triggers.GitCommitID, "$(body.head_commit.id)"),
 		createBindingParam("gitrepositoryurl", "$(body.repository.clone_url)"),
 		createBindingParam("fullname", "$(body.repository.full_name)"),
-		createBindingParam("commitdate", "$(body.head_commit.timestamp)"),
-		createBindingParam("commitmessage", "$(body.head_commit.message"),
-		createBindingParam("commitauthor", "$(body.head_commit.author.name)"),
+		createBindingParam(triggers.GitCommitDate, "$(body.head_commit.timestamp)"),
+		createBindingParam(triggers.GitCommitMessage, "$(body.head_commit.message"),
+		createBindingParam(triggers.GitCommitAuthor, "$(body.head_commit.author.name)"),
 	}
 }
 

--- a/pkg/pipelines/scm/github_test.go
+++ b/pkg/pipelines/scm/github_test.go
@@ -22,16 +22,20 @@ func TestCreatePushBindingForGithub(t *testing.T) {
 		Spec: triggersv1.TriggerBindingSpec{
 			Params: []triggersv1.Param{
 				{
+					Name:  "gitrepositoryurl",
+					Value: "$(body.repository.clone_url)",
+				},
+				{
+					Name:  "fullname",
+					Value: "$(body.repository.full_name)",
+				},
+				{
 					Name:  triggers.GitRef,
 					Value: "$(body.ref)",
 				},
 				{
 					Name:  triggers.GitCommitID,
 					Value: "$(body.head_commit.id)",
-				},
-				{
-					Name:  "gitrepositoryurl",
-					Value: "$(body.repository.clone_url)",
 				},
 				{
 					Name:  triggers.GitCommitDate,

--- a/pkg/pipelines/scm/github_test.go
+++ b/pkg/pipelines/scm/github_test.go
@@ -22,11 +22,11 @@ func TestCreatePushBindingForGithub(t *testing.T) {
 		Spec: triggersv1.TriggerBindingSpec{
 			Params: []triggersv1.Param{
 				{
-					Name:  "io.openshift.build.commit.ref",
+					Name:  triggers.GitRef,
 					Value: "$(body.ref)",
 				},
 				{
-					Name:  "io.openshift.build.commit.id",
+					Name:  triggers.GitCommitID,
 					Value: "$(body.head_commit.id)",
 				},
 				{
@@ -34,15 +34,15 @@ func TestCreatePushBindingForGithub(t *testing.T) {
 					Value: "$(body.repository.clone_url)",
 				},
 				{
-					Name:  "io.openshift.build.commit.date",
+					Name:  triggers.GitCommitDate,
 					Value: "$(body.head_commit.timestamp)",
 				},
 				{
-					Name:  "io.openshift.build.commit.message",
+					Name:  triggers.GitCommitMessage,
 					Value: "$(body.head_commit.message",
 				},
 				{
-					Name:  "io.openshift.build.commit.author",
+					Name:  triggers.GitCommitAuthor,
 					Value: "$(body.head_commit.author.name)",
 				},
 			},

--- a/pkg/pipelines/scm/github_test.go
+++ b/pkg/pipelines/scm/github_test.go
@@ -39,7 +39,7 @@ func TestCreatePushBindingForGithub(t *testing.T) {
 				},
 				{
 					Name:  triggers.GitCommitMessage,
-					Value: "$(body.head_commit.message",
+					Value: "$(body.head_commit.message)",
 				},
 				{
 					Name:  triggers.GitCommitAuthor,

--- a/pkg/pipelines/scm/github_test.go
+++ b/pkg/pipelines/scm/github_test.go
@@ -21,10 +21,30 @@ func TestCreatePushBindingForGithub(t *testing.T) {
 		},
 		Spec: triggersv1.TriggerBindingSpec{
 			Params: []triggersv1.Param{
-				{Name: "gitref", Value: "$(body.ref)"},
-				{Name: "gitsha", Value: "$(body.head_commit.id)"},
-				{Name: "gitrepositoryurl", Value: "$(body.repository.clone_url)"},
-				{Name: "fullname", Value: "$(body.repository.full_name)"},
+				{
+					Name:  "io.openshift.build.commit.ref",
+					Value: "$(body.ref)",
+				},
+				{
+					Name:  "io.openshift.build.commit.id",
+					Value: "$(body.head_commit.id)",
+				},
+				{
+					Name:  "gitrepositoryurl",
+					Value: "$(body.repository.clone_url)",
+				},
+				{
+					Name:  "io.openshift.build.commit.date",
+					Value: "$(body.head_commit.timestamp)",
+				},
+				{
+					Name:  "io.openshift.build.commit.message",
+					Value: "$(body.head_commit.message",
+				},
+				{
+					Name:  "io.openshift.build.commit.author",
+					Value: "$(body.head_commit.author.name)",
+				},
 			},
 		},
 	}

--- a/pkg/pipelines/scm/gitlab.go
+++ b/pkg/pipelines/scm/gitlab.go
@@ -50,9 +50,9 @@ func (r *gitlabSpec) pushBindingParams() []triggersv1.Param {
 		createBindingParam("io.openshift.build.commit.id", "$(body.after)"),
 		createBindingParam("gitrepositoryurl", "$(body.project.git_http_url)"),
 		createBindingParam("fullname", "$(body.project.path_with_namespace)"),
-		// createBindingParam("io.openshift.build.commit.date", "$(body.head_commit.timestamp)"),
-		// createBindingParam("io.openshift.build.commit.message", "$(body.head_commit.message"),
-		createBindingParam("io.openshift.build.commit.author", "$(body.user_username)"),
+		createBindingParam("io.openshift.build.commit.date", "$(body.commits[body.commits.length-1].timestamp)"),
+		createBindingParam("io.openshift.build.commit.message", "(body.commits[body.commits.length-1].message)"),
+		createBindingParam("io.openshift.build.commit.author", "$(body.commits[body.commits.length-1].author.name)"),
 	}
 }
 

--- a/pkg/pipelines/scm/gitlab.go
+++ b/pkg/pipelines/scm/gitlab.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/openshift/odo/pkg/pipelines/triggers"
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 )
 
@@ -46,13 +47,13 @@ func (r *gitlabSpec) pushBindingName() string {
 
 func (r *gitlabSpec) pushBindingParams() []triggersv1.Param {
 	return []triggersv1.Param{
-		createBindingParam("io.openshift.build.commit.ref", "$(body.ref)"),
-		createBindingParam("io.openshift.build.commit.id", "$(body.after)"),
+		createBindingParam(triggers.GitRef, "$(body.ref)"),
+		createBindingParam(triggers.GitCommitID, "$(body.after)"),
 		createBindingParam("gitrepositoryurl", "$(body.project.git_http_url)"),
 		createBindingParam("fullname", "$(body.project.path_with_namespace)"),
-		createBindingParam("io.openshift.build.commit.date", "$(body.commits[body.commits.length-1].timestamp)"),
-		createBindingParam("io.openshift.build.commit.message", "(body.commits[body.commits.length-1].message)"),
-		createBindingParam("io.openshift.build.commit.author", "$(body.commits[body.commits.length-1].author.name)"),
+		createBindingParam(triggers.GitCommitDate, "$(body.commits[body.commits.length-1].timestamp)"),
+		createBindingParam(triggers.GitCommitMessage, "(body.commits[body.commits.length-1].message)"),
+		createBindingParam(triggers.GitCommitAuthor, "$(body.commits[body.commits.length-1].author.name)"),
 	}
 }
 

--- a/pkg/pipelines/scm/gitlab.go
+++ b/pkg/pipelines/scm/gitlab.go
@@ -46,10 +46,13 @@ func (r *gitlabSpec) pushBindingName() string {
 
 func (r *gitlabSpec) pushBindingParams() []triggersv1.Param {
 	return []triggersv1.Param{
-		createBindingParam("gitref", "$(body.ref)"),
-		createBindingParam("gitsha", "$(body.after)"),
+		createBindingParam("io.openshift.build.commit.ref", "$(body.ref)"),
+		createBindingParam("io.openshift.build.commit.id", "$(body.after)"),
 		createBindingParam("gitrepositoryurl", "$(body.project.git_http_url)"),
 		createBindingParam("fullname", "$(body.project.path_with_namespace)"),
+		// createBindingParam("io.openshift.build.commit.date", "$(body.head_commit.timestamp)"),
+		// createBindingParam("io.openshift.build.commit.message", "$(body.head_commit.message"),
+		createBindingParam("io.openshift.build.commit.author", "$(body.user_username)"),
 	}
 }
 

--- a/pkg/pipelines/scm/gitlab.go
+++ b/pkg/pipelines/scm/gitlab.go
@@ -47,13 +47,13 @@ func (r *gitlabSpec) pushBindingName() string {
 
 func (r *gitlabSpec) pushBindingParams() []triggersv1.Param {
 	return []triggersv1.Param{
-		createBindingParam(triggers.GitRef, "$(body.ref)"),
-		createBindingParam(triggers.GitCommitID, "$(body.after)"),
 		createBindingParam("gitrepositoryurl", "$(body.project.git_http_url)"),
 		createBindingParam("fullname", "$(body.project.path_with_namespace)"),
-		createBindingParam(triggers.GitCommitDate, "$(body.commits[body.commits.length-1].timestamp)"),
-		createBindingParam(triggers.GitCommitMessage, "(body.commits[body.commits.length-1].message)"),
-		createBindingParam(triggers.GitCommitAuthor, "$(body.commits[body.commits.length-1].author.name)"),
+		createBindingParam(triggers.GitRef, "$(body.ref)"),
+		createBindingParam(triggers.GitCommitID, "$(body.after)"),
+		createBindingParam(triggers.GitCommitDate, "$(body.commits[-1:].timestamp)"),
+		createBindingParam(triggers.GitCommitMessage, "$(body.commits[-1:].message)"),
+		createBindingParam(triggers.GitCommitAuthor, "$(body.commits[-1:].author.name)"),
 	}
 }
 

--- a/pkg/pipelines/scm/gitlab_test.go
+++ b/pkg/pipelines/scm/gitlab_test.go
@@ -21,10 +21,22 @@ func TestCreatePushBindingForGitlab(t *testing.T) {
 		},
 		Spec: triggersv1.TriggerBindingSpec{
 			Params: []triggersv1.Param{
-				{Name: "gitref", Value: "$(body.ref)"},
-				{Name: "gitsha", Value: "$(body.after)"},
-				{Name: "gitrepositoryurl", Value: "$(body.project.git_http_url)"},
-				{Name: "fullname", Value: "$(body.project.path_with_namespace)"},
+				{
+					Name:  "io.openshift.build.commit.ref",
+					Value: "$(body.ref)",
+				},
+				{
+					Name:  "io.openshift.build.commit.id",
+					Value: "$(body.after)",
+				},
+				{
+					Name:  "gitrepositoryurl",
+					Value: "$(body.project.git_http_url)",
+				},
+				{
+					Name:  "io.openshift.build.commit.author",
+					Value: "$(body.user_username)",
+				},
 			},
 		},
 	}

--- a/pkg/pipelines/scm/gitlab_test.go
+++ b/pkg/pipelines/scm/gitlab_test.go
@@ -22,6 +22,14 @@ func TestCreatePushBindingForGitlab(t *testing.T) {
 		Spec: triggersv1.TriggerBindingSpec{
 			Params: []triggersv1.Param{
 				{
+					Name:  "gitrepositoryurl",
+					Value: "$(body.project.git_http_url)",
+				},
+				{
+					Name:  "fullname",
+					Value: "$(body.project.path_with_namespace)",
+				},
+				{
 					Name:  triggers.GitRef,
 					Value: "$(body.ref)",
 				},
@@ -30,21 +38,17 @@ func TestCreatePushBindingForGitlab(t *testing.T) {
 					Value: "$(body.after)",
 				},
 				{
-					Name:  "gitrepositoryurl",
-					Value: "$(body.project.git_http_url)",
-				},
-				{
 					Name:  triggers.GitCommitDate,
-					Value: "$(body.commits[body.commits.length-1].timestamp)",
+					Value: "$(body.commits[-1:].timestamp)",
 				},
 
 				{
 					Name:  triggers.GitCommitMessage,
-					Value: "(body.commits[body.commits.length-1].message)",
+					Value: "$(body.commits[-1:].message)",
 				},
 				{
 					Name:  triggers.GitCommitAuthor,
-					Value: "$(body.commits[body.commits.length-1].author.name)",
+					Value: "$(body.commits[-1:].author.name)",
 				},
 			},
 		},

--- a/pkg/pipelines/scm/gitlab_test.go
+++ b/pkg/pipelines/scm/gitlab_test.go
@@ -22,11 +22,11 @@ func TestCreatePushBindingForGitlab(t *testing.T) {
 		Spec: triggersv1.TriggerBindingSpec{
 			Params: []triggersv1.Param{
 				{
-					Name:  "io.openshift.build.commit.ref",
+					Name:  triggers.GitRef,
 					Value: "$(body.ref)",
 				},
 				{
-					Name:  "io.openshift.build.commit.id",
+					Name:  triggers.GitCommitID,
 					Value: "$(body.after)",
 				},
 				{
@@ -34,16 +34,16 @@ func TestCreatePushBindingForGitlab(t *testing.T) {
 					Value: "$(body.project.git_http_url)",
 				},
 				{
-					Name:  "io.openshift.build.commit.date",
+					Name:  triggers.GitCommitDate,
 					Value: "$(body.commits[body.commits.length-1].timestamp)",
 				},
 
 				{
-					Name:  "io.openshift.build.commit.message",
+					Name:  triggers.GitCommitMessage,
 					Value: "(body.commits[body.commits.length-1].message)",
 				},
 				{
-					Name:  "io.openshift.build.commit.author",
+					Name:  triggers.GitCommitAuthor,
 					Value: "$(body.commits[body.commits.length-1].author.name)",
 				},
 			},

--- a/pkg/pipelines/scm/gitlab_test.go
+++ b/pkg/pipelines/scm/gitlab_test.go
@@ -34,8 +34,17 @@ func TestCreatePushBindingForGitlab(t *testing.T) {
 					Value: "$(body.project.git_http_url)",
 				},
 				{
+					Name:  "io.openshift.build.commit.date",
+					Value: "$(body.commits[body.commits.length-1].timestamp)",
+				},
+
+				{
+					Name:  "io.openshift.build.commit.message",
+					Value: "(body.commits[body.commits.length-1].message)",
+				},
+				{
 					Name:  "io.openshift.build.commit.author",
-					Value: "$(body.user_username)",
+					Value: "$(body.commits[body.commits.length-1].author.name)",
 				},
 			},
 		},

--- a/pkg/pipelines/triggers/bindings_test.go
+++ b/pkg/pipelines/triggers/bindings_test.go
@@ -11,13 +11,13 @@ import (
 
 func TestCreateBindingParam(t *testing.T) {
 	validParam := pipelinev1.Param{
-		Name: "gitref",
+		Name: "io.openshift.build.commit.ref",
 		Value: pipelinev1.ArrayOrString{
 			StringVal: "$(body.ref)",
 			Type:      pipelinev1.ParamTypeString,
 		},
 	}
-	bindingParam := createPipelineBindingParam("gitref", "$(body.ref)")
+	bindingParam := createPipelineBindingParam("io.openshift.build.commit.ref", "$(body.ref)")
 	if diff := cmp.Diff(validParam, bindingParam); diff != "" {
 		t.Fatalf("createPipelineBindingParam() failed\n%s", diff)
 	}

--- a/pkg/pipelines/triggers/bindings_test.go
+++ b/pkg/pipelines/triggers/bindings_test.go
@@ -11,13 +11,13 @@ import (
 
 func TestCreateBindingParam(t *testing.T) {
 	validParam := pipelinev1.Param{
-		Name: "io.openshift.build.commit.ref",
+		Name: GitRef,
 		Value: pipelinev1.ArrayOrString{
 			StringVal: "$(body.ref)",
 			Type:      pipelinev1.ParamTypeString,
 		},
 	}
-	bindingParam := createPipelineBindingParam("io.openshift.build.commit.ref", "$(body.ref)")
+	bindingParam := createPipelineBindingParam(GitRef, "$(body.ref)")
 	if diff := cmp.Diff(validParam, bindingParam); diff != "" {
 		t.Fatalf("createPipelineBindingParam() failed\n%s", diff)
 	}

--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -40,7 +40,7 @@ func createDevCIPipelineRun(saName string) pipelinev1.PipelineRun {
 				createPipelineBindingParam("COMMIT_AUTHOR", "$(params."+GitCommitAuthor+")"),
 				createPipelineBindingParam("COMMIT_MESSAGE", "$(params."+GitCommitMessage+")"),
 			},
-			Resources: createDevResource("$(params.io.openshift.build.commit.ref)"),
+			Resources: createDevResource("$(params." + GitRef + ")"),
 		},
 	}
 

--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -34,6 +34,12 @@ func createDevCIPipelineRun(saName string) pipelinev1.PipelineRun {
 				createPipelineBindingParam("REPO", "$(params.fullname)"),
 				createPipelineBindingParam("COMMIT_SHA", "$(params.io.openshift.build.commit.id)"),
 				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
+
+				createPipelineBindingParam("GIT_REF", "$(params.io.openshift.build.commit.ref)"),
+				createPipelineBindingParam("COMMIT_DATE", "$(params.io.openshift.build.commit.date)"),
+				createPipelineBindingParam("COMMIT_AUTHOR", "$(params.io.openshift.build.commit.author)"),
+				createPipelineBindingParam("COMMIT_MESSAGE", "$(params.io.openshift.build.commit.message)"),
+				createPipelineBindingParam("GIT_REPO", "$(params.gitrepositoryurl)"),
 			},
 			Resources: createDevResource("$(params.io.openshift.build.commit.ref)"),
 		},

--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -18,7 +18,7 @@ func createDevCDPipelineRun(saName string) pipelinev1.PipelineRun {
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
 			PipelineRef:        createPipelineRef("app-cd-pipeline"),
-			Resources:          createDevResource("$(params.gitsha)"),
+			Resources:          createDevResource("$(params.io.openshift.build.commit.id)"),
 		},
 	}
 }
@@ -32,10 +32,10 @@ func createDevCIPipelineRun(saName string) pipelinev1.PipelineRun {
 			PipelineRef:        createPipelineRef("app-ci-pipeline"),
 			Params: []pipelinev1.Param{
 				createPipelineBindingParam("REPO", "$(params.fullname)"),
-				createPipelineBindingParam("COMMIT_SHA", "$(params.gitsha)"),
+				createPipelineBindingParam("COMMIT_SHA", "$(params.io.openshift.build.commit.id)"),
 				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
 			},
-			Resources: createDevResource("$(params.gitref)"),
+			Resources: createDevResource("$(params.io.openshift.build.commit.ref)"),
 		},
 	}
 
@@ -83,7 +83,7 @@ func createDevResource(revision string) []pipelinev1.PipelineResourceBinding {
 			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
 				Type: "image",
 				Params: []pipelinev1.ResourceParam{
-					createResourceParams("url", "$(params.imageRepo):$(params.gitref)-$(params.gitsha)"),
+					createResourceParams("url", "$(params.imageRepo):$(params.io.openshift.build.commit.ref)-$(params.io.openshift.build.commit.id)"),
 				},
 			},
 		},
@@ -97,7 +97,7 @@ func createResources() []pipelinev1.PipelineResourceBinding {
 			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
 				Type: "git",
 				Params: []pipelinev1.ResourceParam{
-					createResourceParams("revision", "$(params.gitref)"),
+					createResourceParams("revision", "$(params.io.openshift.build.commit.ref)"),
 					createResourceParams("url", "$(params.gitrepositoryurl)"),
 				},
 			},

--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -18,7 +18,7 @@ func createDevCDPipelineRun(saName string) pipelinev1.PipelineRun {
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
 			PipelineRef:        createPipelineRef("app-cd-pipeline"),
-			Resources:          createDevResource("$(params.io.openshift.build.commit.id)"),
+			Resources:          createDevResource("$(params." + GitCommitID + ")"),
 		},
 	}
 }
@@ -32,14 +32,13 @@ func createDevCIPipelineRun(saName string) pipelinev1.PipelineRun {
 			PipelineRef:        createPipelineRef("app-ci-pipeline"),
 			Params: []pipelinev1.Param{
 				createPipelineBindingParam("REPO", "$(params.fullname)"),
-				createPipelineBindingParam("COMMIT_SHA", "$(params.io.openshift.build.commit.id)"),
-				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
-
-				createPipelineBindingParam("GIT_REF", "$(params.io.openshift.build.commit.ref)"),
-				createPipelineBindingParam("COMMIT_DATE", "$(params.io.openshift.build.commit.date)"),
-				createPipelineBindingParam("COMMIT_AUTHOR", "$(params.io.openshift.build.commit.author)"),
-				createPipelineBindingParam("COMMIT_MESSAGE", "$(params.io.openshift.build.commit.message)"),
 				createPipelineBindingParam("GIT_REPO", "$(params.gitrepositoryurl)"),
+				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
+				createPipelineBindingParam("COMMIT_SHA", "$(params."+GitCommitID+")"),
+				createPipelineBindingParam("GIT_REF", "$(params."+GitRef+")"),
+				createPipelineBindingParam("COMMIT_DATE", "$(params."+GitCommitDate+")"),
+				createPipelineBindingParam("COMMIT_AUTHOR", "$(params."+GitCommitAuthor+")"),
+				createPipelineBindingParam("COMMIT_MESSAGE", "$(params."+GitCommitMessage+")"),
 			},
 			Resources: createDevResource("$(params.io.openshift.build.commit.ref)"),
 		},
@@ -89,7 +88,7 @@ func createDevResource(revision string) []pipelinev1.PipelineResourceBinding {
 			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
 				Type: "image",
 				Params: []pipelinev1.ResourceParam{
-					createResourceParams("url", "$(params.imageRepo):$(params.io.openshift.build.commit.ref)-$(params.io.openshift.build.commit.id)"),
+					createResourceParams("url", "$(params.imageRepo):$(params."+GitRef+")-$(params."+GitCommitID+")"),
 				},
 			},
 		},
@@ -103,7 +102,7 @@ func createResources() []pipelinev1.PipelineResourceBinding {
 			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
 				Type: "git",
 				Params: []pipelinev1.ResourceParam{
-					createResourceParams("revision", "$(params.io.openshift.build.commit.ref)"),
+					createResourceParams("revision", "$(params."+GitRef+")"),
 					createResourceParams("url", "$(params.gitrepositoryurl)"),
 				},
 			},

--- a/pkg/pipelines/triggers/pipelinerun_test.go
+++ b/pkg/pipelines/triggers/pipelinerun_test.go
@@ -21,7 +21,7 @@ func TestCreateDevCDPipelineRun(t *testing.T) {
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: sName,
 			PipelineRef:        createPipelineRef("app-cd-pipeline"),
-			Resources:          createDevResource("$(params.gitsha)"),
+			Resources:          createDevResource("$(params.io.openshift.build.commit.id)"),
 		},
 	}
 	template := createDevCDPipelineRun(sName)
@@ -40,10 +40,10 @@ func TestCreateDevCIPipelineRun(t *testing.T) {
 			PipelineRef:        createPipelineRef("app-ci-pipeline"),
 			Params: []pipelinev1.Param{
 				createPipelineBindingParam("REPO", "$(params.fullname)"),
-				createPipelineBindingParam("COMMIT_SHA", "$(params.gitsha)"),
+				createPipelineBindingParam("COMMIT_SHA", "$(params.io.openshift.build.commit.id)"),
 				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
 			},
-			Resources: createDevResource("$(params.gitref)"),
+			Resources: createDevResource("$(params.io.openshift.build.commit.ref)"),
 		},
 	}
 	template := createDevCIPipelineRun(sName)
@@ -101,7 +101,7 @@ func TestCreateDevResource(t *testing.T) {
 			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
 				Type: "image",
 				Params: []pipelinev1.ResourceParam{
-					createResourceParams("url", "$(params.imageRepo):$(params.gitref)-$(params.gitsha)"),
+					createResourceParams("url", "$(params.imageRepo):$(params.io.openshift.build.commit.ref)-$(params.io.openshift.build.commit.id)"),
 				},
 			},
 		},

--- a/pkg/pipelines/triggers/pipelinerun_test.go
+++ b/pkg/pipelines/triggers/pipelinerun_test.go
@@ -42,6 +42,12 @@ func TestCreateDevCIPipelineRun(t *testing.T) {
 				createPipelineBindingParam("REPO", "$(params.fullname)"),
 				createPipelineBindingParam("COMMIT_SHA", "$(params.io.openshift.build.commit.id)"),
 				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
+
+				createPipelineBindingParam("GIT_REF", "$(params.io.openshift.build.commit.ref)"),
+				createPipelineBindingParam("COMMIT_DATE", "$(params.io.openshift.build.commit.date)"),
+				createPipelineBindingParam("COMMIT_AUTHOR", "$(params.io.openshift.build.commit.author)"),
+				createPipelineBindingParam("COMMIT_MESSAGE", "$(params.io.openshift.build.commit.message)"),
+				createPipelineBindingParam("GIT_REPO", "$(params.gitrepositoryurl)"),
 			},
 			Resources: createDevResource("$(params.io.openshift.build.commit.ref)"),
 		},

--- a/pkg/pipelines/triggers/pipelinerun_test.go
+++ b/pkg/pipelines/triggers/pipelinerun_test.go
@@ -40,14 +40,13 @@ func TestCreateDevCIPipelineRun(t *testing.T) {
 			PipelineRef:        createPipelineRef("app-ci-pipeline"),
 			Params: []pipelinev1.Param{
 				createPipelineBindingParam("REPO", "$(params.fullname)"),
-				createPipelineBindingParam("COMMIT_SHA", "$(params.io.openshift.build.commit.id)"),
+				createPipelineBindingParam("GIT_REPO", "$(params.gitrepositoryurl)"),
 				createPipelineBindingParam("TLSVERIFY", "$(params.tlsVerify)"),
-
+				createPipelineBindingParam("COMMIT_SHA", "$(params.io.openshift.build.commit.id)"),
 				createPipelineBindingParam("GIT_REF", "$(params.io.openshift.build.commit.ref)"),
 				createPipelineBindingParam("COMMIT_DATE", "$(params.io.openshift.build.commit.date)"),
 				createPipelineBindingParam("COMMIT_AUTHOR", "$(params.io.openshift.build.commit.author)"),
 				createPipelineBindingParam("COMMIT_MESSAGE", "$(params.io.openshift.build.commit.message)"),
-				createPipelineBindingParam("GIT_REPO", "$(params.gitrepositoryurl)"),
 			},
 			Resources: createDevResource("$(params.io.openshift.build.commit.ref)"),
 		},

--- a/pkg/pipelines/triggers/templates.go
+++ b/pkg/pipelines/triggers/templates.go
@@ -14,6 +14,14 @@ var (
 	triggerTemplateTypeMeta = meta.TypeMeta("TriggerTemplate", "triggers.tekton.dev/v1alpha1")
 )
 
+const (
+	GitRef           = "io.openshift.build.commit.ref"
+	GitCommitID      = "io.openshift.build.commit.id"
+	GitCommitAuthor  = "io.openshift.build.commit.author"
+	GitCommitMessage = "io.openshift.build.commit.message"
+	GitCommitDate    = "io.openshift.build.commit.date"
+)
+
 // GenerateTemplates will return a slice of trigger templates
 func GenerateTemplates(ns, saName string) []triggersv1.TriggerTemplate {
 	return []triggersv1.TriggerTemplate{
@@ -31,7 +39,7 @@ func CreateDevCDDeployTemplate(ns, saName string) triggersv1.TriggerTemplate {
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, "app-cd-template")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-				createTemplateParamSpec("io.openshift.build.commit.id", "The specific commit SHA."),
+				createTemplateParamSpec(GitCommitID, "The specific commit SHA."),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
@@ -54,15 +62,15 @@ func CreateDevCIBuildPRTemplate(ns, saName string) triggersv1.TriggerTemplate {
 			statusTrackerAnnotations("dev-ci-build-from-pr", "Dev CI Build")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-				createTemplateParamSpec("io.openshift.build.commit.ref", "The git branch for this PR."),
-				createTemplateParamSpec("io.openshift.build.commit.id", "the specific commit SHA."),
+				createTemplateParamSpec(GitRef, "The git branch for this PR."),
+				createTemplateParamSpec(GitCommitID, "the specific commit SHA."),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository URL."),
 				createTemplateParamSpec("fullname", "The GitHub repository for this PullRequest."),
 				createTemplateParamSpec("imageRepo", "The repository to push built images to."),
 				createTemplateParamSpec("tlsVerify", "Enable image repostiory TLS certification verification."),
-				createTemplateParamSpec("io.openshift.build.commit.date", "The date at which the commit was made"),
-				createTemplateParamSpec("io.openshift.build.commit.author", "The name of the github user handle that made the commit"),
-				createTemplateParamSpec("io.openshift.build.commit.message", "The commit message"),
+				createTemplateParamSpec(GitCommitDate, "The date at which the commit was made"),
+				createTemplateParamSpec(GitCommitAuthor, "The name of the github user handle that made the commit"),
+				createTemplateParamSpec(GitCommitMessage, "The commit message"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{
@@ -84,11 +92,11 @@ func CreateCDPushTemplate(ns, saName string) triggersv1.TriggerTemplate {
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 
-				createTemplateParamSpecDefault("io.openshift.build.commit.ref", "The git revision", "master"),
+				createTemplateParamSpecDefault(GitRef, "The git revision", "master"),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
-				createTemplateParamSpec("io.openshift.build.commit.date", "The date at which the commit was made"),
-				createTemplateParamSpec("io.openshift.build.commit.author", "The name of the github user handle that made the commit"),
-				createTemplateParamSpec("io.openshift.build.commit.message", "The commit message"),
+				createTemplateParamSpec(GitCommitDate, "The date at which the commit was made"),
+				createTemplateParamSpec(GitCommitAuthor, "The name of the github user handle that made the commit"),
+				createTemplateParamSpec(GitCommitMessage, "The commit message"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{
@@ -109,7 +117,7 @@ func CreateCIDryRunTemplate(ns, saName string) triggersv1.TriggerTemplate {
 			statusTrackerAnnotations("ci-dryrun-from-push-pipeline", "CI dry run on push event")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-				createTemplateParamSpecDefault("io.openshift.build.commit.ref", "The git revision", "master"),
+				createTemplateParamSpecDefault(GitRef, "The git revision", "master"),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{

--- a/pkg/pipelines/triggers/templates.go
+++ b/pkg/pipelines/triggers/templates.go
@@ -31,7 +31,7 @@ func CreateDevCDDeployTemplate(ns, saName string) triggersv1.TriggerTemplate {
 		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, "app-cd-template")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-				createTemplateParamSpec("gitsha", "The specific commit SHA."),
+				createTemplateParamSpec("io.openshift.build.commit.id", "The specific commit SHA."),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
@@ -54,8 +54,8 @@ func CreateDevCIBuildPRTemplate(ns, saName string) triggersv1.TriggerTemplate {
 			statusTrackerAnnotations("dev-ci-build-from-pr", "Dev CI Build")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-				createTemplateParamSpec("gitref", "The git branch for this PR."),
-				createTemplateParamSpec("gitsha", "the specific commit SHA."),
+				createTemplateParamSpec("io.openshift.build.commit.ref", "The git branch for this PR."),
+				createTemplateParamSpec("io.openshift.build.commit.id", "the specific commit SHA."),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository URL."),
 				createTemplateParamSpec("fullname", "The GitHub repository for this PullRequest."),
 				createTemplateParamSpec("imageRepo", "The repository to push built images to."),
@@ -106,7 +106,7 @@ func CreateCIDryRunTemplate(ns, saName string) triggersv1.TriggerTemplate {
 			statusTrackerAnnotations("ci-dryrun-from-push-pipeline", "CI dry run on push event")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-				createTemplateParamSpecDefault("gitref", "The git revision", "master"),
+				createTemplateParamSpecDefault("io.openshift.build.commit.ref", "The git revision", "master"),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{

--- a/pkg/pipelines/triggers/templates.go
+++ b/pkg/pipelines/triggers/templates.go
@@ -60,6 +60,9 @@ func CreateDevCIBuildPRTemplate(ns, saName string) triggersv1.TriggerTemplate {
 				createTemplateParamSpec("fullname", "The GitHub repository for this PullRequest."),
 				createTemplateParamSpec("imageRepo", "The repository to push built images to."),
 				createTemplateParamSpec("tlsVerify", "Enable image repostiory TLS certification verification."),
+				createTemplateParamSpec("io.openshift.build.commit.date", "The date at which the commit was made"),
+				createTemplateParamSpec("io.openshift.build.commit.author", "The name of the github user handle that made the commit"),
+				createTemplateParamSpec("io.openshift.build.commit.message", "The commit message"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{

--- a/pkg/pipelines/triggers/templates.go
+++ b/pkg/pipelines/triggers/templates.go
@@ -81,11 +81,11 @@ func CreateCDPushTemplate(ns, saName string) triggersv1.TriggerTemplate {
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 
-				createTemplateParamSpecDefault("gitref", "The git revision", "master"),
+				createTemplateParamSpecDefault("io.openshift.build.commit.ref", "The git revision", "master"),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
-				createTemplateParamSpec("commitdate", "The date at which the commit was made"),
-				createTemplateParamSpec("commitauthor", "The name of the github user handle that made the commit"),
-				createTemplateParamSpec("commitmessage", "The commit message"),
+				createTemplateParamSpec("io.openshift.build.commit.date", "The date at which the commit was made"),
+				createTemplateParamSpec("io.openshift.build.commit.author", "The name of the github user handle that made the commit"),
+				createTemplateParamSpec("io.openshift.build.commit.message", "The commit message"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{

--- a/pkg/pipelines/triggers/templates.go
+++ b/pkg/pipelines/triggers/templates.go
@@ -83,6 +83,9 @@ func CreateCDPushTemplate(ns, saName string) triggersv1.TriggerTemplate {
 
 				createTemplateParamSpecDefault("gitref", "The git revision", "master"),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
+				createTemplateParamSpec("commitdate", "The date at which the commit was made"),
+				createTemplateParamSpec("commitauthor", "The name of the github user handle that made the commit"),
+				createTemplateParamSpec("commitmessage", "The commit message"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{

--- a/pkg/pipelines/triggers/templates.go
+++ b/pkg/pipelines/triggers/templates.go
@@ -64,13 +64,13 @@ func CreateDevCIBuildPRTemplate(ns, saName string) triggersv1.TriggerTemplate {
 			Params: []triggersv1.ParamSpec{
 				createTemplateParamSpec(GitRef, "The git branch for this PR."),
 				createTemplateParamSpec(GitCommitID, "the specific commit SHA."),
+				createTemplateParamSpec(GitCommitDate, "The date at which the commit was made"),
+				createTemplateParamSpec(GitCommitAuthor, "The name of the github user handle that made the commit"),
+				createTemplateParamSpec(GitCommitMessage, "The commit message"),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository URL."),
 				createTemplateParamSpec("fullname", "The GitHub repository for this PullRequest."),
 				createTemplateParamSpec("imageRepo", "The repository to push built images to."),
 				createTemplateParamSpec("tlsVerify", "Enable image repostiory TLS certification verification."),
-				createTemplateParamSpec(GitCommitDate, "The date at which the commit was made"),
-				createTemplateParamSpec(GitCommitAuthor, "The name of the github user handle that made the commit"),
-				createTemplateParamSpec(GitCommitMessage, "The commit message"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{
@@ -93,10 +93,10 @@ func CreateCDPushTemplate(ns, saName string) triggersv1.TriggerTemplate {
 			Params: []triggersv1.ParamSpec{
 
 				createTemplateParamSpecDefault(GitRef, "The git revision", "master"),
-				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
 				createTemplateParamSpec(GitCommitDate, "The date at which the commit was made"),
 				createTemplateParamSpec(GitCommitAuthor, "The name of the github user handle that made the commit"),
 				createTemplateParamSpec(GitCommitMessage, "The commit message"),
+				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{

--- a/pkg/pipelines/triggers/templates_test.go
+++ b/pkg/pipelines/triggers/templates_test.go
@@ -22,7 +22,7 @@ func TestCreateDevCDDeployTemplate(t *testing.T) {
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
-					Name:        "io.openshift.build.commit.id",
+					Name:        GitCommitID,
 					Description: "The specific commit SHA.",
 				},
 				{
@@ -55,11 +55,11 @@ func TestCreateDevCIBuildPRTemplate(t *testing.T) {
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
-					Name:        "io.openshift.build.commit.ref",
+					Name:        GitRef,
 					Description: "The git branch for this PR.",
 				},
 				{
-					Name:        "io.openshift.build.commit.id",
+					Name:        GitCommitID,
 					Description: "the specific commit SHA.",
 				},
 				{
@@ -79,15 +79,15 @@ func TestCreateDevCIBuildPRTemplate(t *testing.T) {
 					Description: "Enable image repostiory TLS certification verification.",
 				},
 				{
-					Name:        "io.openshift.build.commit.date",
+					Name:        GitCommitDate,
 					Description: "The date at which the commit was made",
 				},
 				{
-					Name:        "io.openshift.build.commit.author",
+					Name:        GitCommitAuthor,
 					Description: "The name of the github user handle that made the commit",
 				},
 				{
-					Name:        "io.openshift.build.commit.message",
+					Name:        GitCommitMessage,
 					Description: "The commit message",
 				},
 			},
@@ -113,7 +113,7 @@ func TestCreateCDPushTemplate(t *testing.T) {
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
-					Name:        "io.openshift.build.commit.ref",
+					Name:        GitRef,
 					Description: "The git revision",
 					Default:     strPtr("master"),
 				},
@@ -122,15 +122,15 @@ func TestCreateCDPushTemplate(t *testing.T) {
 					Description: "The git repository url",
 				},
 				{
-					Name:        "io.openshift.build.commit.date",
+					Name:        GitCommitDate,
 					Description: "The date at which the commit was made",
 				},
 				{
-					Name:        "io.openshift.build.commit.author",
+					Name:        GitCommitAuthor,
 					Description: "The name of the github user handle that made the commit",
 				},
 				{
-					Name:        "io.openshift.build.commit.message",
+					Name:        GitCommitMessage,
 					Description: "The commit message",
 				},
 			},
@@ -158,7 +158,7 @@ func TestCreateCIDryRunTemplate(t *testing.T) {
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
-					Name:        "io.openshift.build.commit.ref",
+					Name:        GitRef,
 					Description: "The git revision",
 					Default:     strPtr("master"),
 				},

--- a/pkg/pipelines/triggers/templates_test.go
+++ b/pkg/pipelines/triggers/templates_test.go
@@ -78,6 +78,18 @@ func TestCreateDevCIBuildPRTemplate(t *testing.T) {
 					Name:        "tlsVerify",
 					Description: "Enable image repostiory TLS certification verification.",
 				},
+				{
+					Name:        "io.openshift.build.commit.date",
+					Description: "The date at which the commit was made",
+				},
+				{
+					Name:        "io.openshift.build.commit.author",
+					Description: "The name of the github user handle that made the commit",
+				},
+				{
+					Name:        "io.openshift.build.commit.message",
+					Description: "The commit message",
+				},
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{

--- a/pkg/pipelines/triggers/templates_test.go
+++ b/pkg/pipelines/triggers/templates_test.go
@@ -22,7 +22,7 @@ func TestCreateDevCDDeployTemplate(t *testing.T) {
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
-					Name:        "gitsha",
+					Name:        "io.openshift.build.commit.id",
 					Description: "The specific commit SHA.",
 				},
 				{
@@ -55,11 +55,11 @@ func TestCreateDevCIBuildPRTemplate(t *testing.T) {
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
-					Name:        "gitref",
+					Name:        "io.openshift.build.commit.ref",
 					Description: "The git branch for this PR.",
 				},
 				{
-					Name:        "gitsha",
+					Name:        "io.openshift.build.commit.id",
 					Description: "the specific commit SHA.",
 				},
 				{
@@ -101,13 +101,25 @@ func TestCreateCDPushTemplate(t *testing.T) {
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
-					Name:        "gitref",
+					Name:        "io.openshift.build.commit.ref",
 					Description: "The git revision",
 					Default:     strPtr("master"),
 				},
 				{
 					Name:        "gitrepositoryurl",
 					Description: "The git repository url",
+				},
+				{
+					Name:        "io.openshift.build.commit.date",
+					Description: "The date at which the commit was made",
+				},
+				{
+					Name:        "io.openshift.build.commit.author",
+					Description: "The name of the github user handle that made the commit",
+				},
+				{
+					Name:        "io.openshift.build.commit.message",
+					Description: "The commit message",
 				},
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
@@ -134,7 +146,7 @@ func TestCreateCIDryRunTemplate(t *testing.T) {
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
-					Name:        "gitref",
+					Name:        "io.openshift.build.commit.ref",
 					Description: "The git revision",
 					Default:     strPtr("master"),
 				},

--- a/pkg/pipelines/triggers/templates_test.go
+++ b/pkg/pipelines/triggers/templates_test.go
@@ -63,6 +63,18 @@ func TestCreateDevCIBuildPRTemplate(t *testing.T) {
 					Description: "the specific commit SHA.",
 				},
 				{
+					Name:        GitCommitDate,
+					Description: "The date at which the commit was made",
+				},
+				{
+					Name:        GitCommitAuthor,
+					Description: "The name of the github user handle that made the commit",
+				},
+				{
+					Name:        GitCommitMessage,
+					Description: "The commit message",
+				},
+				{
 					Name:        "gitrepositoryurl",
 					Description: "The git repository URL.",
 				},
@@ -77,18 +89,6 @@ func TestCreateDevCIBuildPRTemplate(t *testing.T) {
 				{
 					Name:        "tlsVerify",
 					Description: "Enable image repostiory TLS certification verification.",
-				},
-				{
-					Name:        GitCommitDate,
-					Description: "The date at which the commit was made",
-				},
-				{
-					Name:        GitCommitAuthor,
-					Description: "The name of the github user handle that made the commit",
-				},
-				{
-					Name:        GitCommitMessage,
-					Description: "The commit message",
 				},
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
@@ -118,10 +118,6 @@ func TestCreateCDPushTemplate(t *testing.T) {
 					Default:     strPtr("master"),
 				},
 				{
-					Name:        "gitrepositoryurl",
-					Description: "The git repository url",
-				},
-				{
 					Name:        GitCommitDate,
 					Description: "The date at which the commit was made",
 				},
@@ -132,6 +128,10 @@ func TestCreateCDPushTemplate(t *testing.T) {
 				{
 					Name:        GitCommitMessage,
 					Description: "The commit message",
+				},
+				{
+					Name:        "gitrepositoryurl",
+					Description: "The git repository url",
 				},
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{


### PR DESCRIPTION
**What type of PR is this?**
/kind design

**What does does this PR do / why we need it**:

It adds EXTRA LABELS  to the buildah , i.e commit message, author, a timestamp for both Github and GitLab.

**Which issue(s) this PR fixes**:
https://issues.redhat.com/browse/GITOPS-222

**How to test changes / Special notes to the reviewer**:
You would need to replace the buildah ClusterTask present with this https://carbon.now.sh/pXX2g6jT0ls6nJrI4SS3
After Successful execution of the app-ci pipeline, the expanded view of the pushed quay image will have the new labels.

co-author - @ishitasequeira 