### PR TITLE
Replace pull request events by push

### DIFF
--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -285,7 +285,7 @@ func defaultPipelines(r scm.Repository) *config.Pipelines {
 	return &config.Pipelines{
 		Integration: &config.TemplateBinding{
 			Template: appCITemplateName,
-			Bindings: []string{r.PRBindingName()},
+			Bindings: []string{r.PushBindingName()},
 		},
 	}
 }

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -66,7 +66,7 @@ func TestBootstrapManifest(t *testing.T) {
 					Pipelines: &config.Pipelines{
 						Integration: &config.TemplateBinding{
 							Template: "app-ci-template",
-							Bindings: []string{"github-pr-binding"},
+							Bindings: []string{"github-push-binding"},
 						},
 					},
 					Name: "tst-dev",
@@ -81,7 +81,7 @@ func TestBootstrapManifest(t *testing.T) {
 								},
 							},
 							Pipelines: &config.Pipelines{
-								Integration: &config.TemplateBinding{Bindings: []string{"tst-dev-http-api-binding", "github-pr-binding"}},
+								Integration: &config.TemplateBinding{Bindings: []string{"tst-dev-http-api-binding", "github-push-binding"}},
 							},
 						},
 					},
@@ -119,11 +119,11 @@ func TestBootstrapManifest(t *testing.T) {
 		"04-tasks/deploy-from-source-task.yaml",
 		"04-tasks/deploy-using-kubectl-task.yaml",
 		"05-pipelines/app-ci-pipeline.yaml",
-		"05-pipelines/ci-dryrun-from-pr-pipeline.yaml",
-		"06-bindings/github-pr-binding.yaml",
+		"05-pipelines/ci-dryrun-from-push-pipeline.yaml",
+		"06-bindings/github-push-binding.yaml",
 		"06-bindings/tst-dev-http-api-binding.yaml",
-		"07-templates/app-ci-build-pr-template.yaml",
-		"07-templates/ci-dryrun-from-pr-template.yaml",
+		"07-templates/app-ci-build-from-push-template.yaml",
+		"07-templates/ci-dryrun-from-push-template.yaml",
 		"08-eventlisteners/cicd-event-listener.yaml",
 		"09-routes/gitops-webhook-event-listener.yaml",
 	}

--- a/pkg/pipelines/environment_test.go
+++ b/pkg/pipelines/environment_test.go
@@ -137,7 +137,7 @@ func TestNewEnvironment(t *testing.T) {
 				Pipelines: &config.Pipelines{
 					Integration: &config.TemplateBinding{
 						Template: appCITemplateName,
-						Bindings: []string{"github-pr-binding"},
+						Bindings: []string{"github-push-binding"},
 					},
 				},
 			},
@@ -162,7 +162,7 @@ func TestNewEnvironment(t *testing.T) {
 				Pipelines: &config.Pipelines{
 					Integration: &config.TemplateBinding{
 						Template: appCITemplateName,
-						Bindings: []string{"gitlab-pr-binding"},
+						Bindings: []string{"gitlab-push-binding"},
 					},
 				},
 			},

--- a/pkg/pipelines/eventlisteners/eventlisteners.go
+++ b/pkg/pipelines/eventlisteners/eventlisteners.go
@@ -28,9 +28,7 @@ func Generate(repo scm.Repository, ns, saName, secretName string) triggersv1.Eve
 		Spec: triggersv1.EventListenerSpec{
 			ServiceAccountName: saName,
 			Triggers: []triggersv1.EventListenerTrigger{
-				repo.CreateCITrigger("ci-dryrun-from-pr", secretName, ns, "ci-dryrun-from-pr-template",
-					[]string{"github-pr-binding"}),
-				repo.CreateCDTrigger("cd-deploy-from-push", secretName, ns, "cd-deploy-from-push-template", []string{"github-push-binding"}),
+				repo.CreatePushTrigger("ci-dryrun-from-push", secretName, ns, "ci-dryrun-from-push-template", []string{"github-push-binding"}),
 			},
 		},
 	}

--- a/pkg/pipelines/eventlisteners/eventlisteners_test.go
+++ b/pkg/pipelines/eventlisteners/eventlisteners_test.go
@@ -20,13 +20,8 @@ func TestGenerateEventListener(t *testing.T) {
 			ServiceAccountName: "pipeline",
 			Triggers: []triggersv1.EventListenerTrigger{
 				{
-					Name: "ci-dryrun-from-pr",
+					Name: "ci-dryrun-from-push",
 					Interceptors: []*triggersv1.EventInterceptor{
-						{
-							CEL: &triggersv1.CELInterceptor{
-								Filter: "(header.match('X-GitHub-Event', 'pull_request') && body.action == 'opened' || body.action == 'synchronize') && body.pull_request.head.repo.full_name == 'org/test'",
-							},
-						},
 						{
 							GitHub: &triggersv1.GitHubInterceptor{
 								SecretRef: &triggersv1.SecretRef{
@@ -36,30 +31,11 @@ func TestGenerateEventListener(t *testing.T) {
 								},
 							},
 						},
-					},
-					Bindings: []*triggersv1.EventListenerBinding{
-						{
-							Name: "github-pr-binding",
-						},
-					},
-					Template: triggersv1.EventListenerTemplate{
-						Name: "ci-dryrun-from-pr-template",
-					},
-				},
-				{
-					Name: "cd-deploy-from-push",
-					Interceptors: []*triggersv1.EventInterceptor{
 						{
 							CEL: &triggersv1.CELInterceptor{
-								Filter: "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'org/test') && body.ref.startsWith('refs/heads/master')",
-							},
-						},
-						{
-							GitHub: &triggersv1.GitHubInterceptor{
-								SecretRef: &triggersv1.SecretRef{
-									SecretName: "test",
-									SecretKey:  WebhookSecretKey,
-									Namespace:  "testing",
+								Filter: "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == 'org/test')",
+								Overlays: []triggersv1.CELOverlay{
+									{Key: "ref", Expression: "split(body.ref,'/')[2]"},
 								},
 							},
 						},
@@ -70,7 +46,7 @@ func TestGenerateEventListener(t *testing.T) {
 						},
 					},
 					Template: triggersv1.EventListenerTemplate{
-						Name: "cd-deploy-from-push-template",
+						Name: "ci-dryrun-from-push-template",
 					},
 				},
 			},

--- a/pkg/pipelines/scm/github.go
+++ b/pkg/pipelines/scm/github.go
@@ -8,13 +8,11 @@ import (
 )
 
 const (
-	githubCIDryRunFilters = "(header.match('X-GitHub-Event', 'pull_request') && body.action == 'opened' || body.action == 'synchronize') && body.pull_request.head.repo.full_name == '%s'"
-	githubCDDeployFilters = "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == '%s') && body.ref.startsWith('refs/heads/master')"
-	githubType            = "github"
+	githubPushEventFilters = "(header.match('X-GitHub-Event', 'push') && body.repository.full_name == '%s')"
+	githubType             = "github"
 )
 
 type githubSpec struct {
-	prBinding   string
 	pushBinding string
 }
 
@@ -27,7 +25,7 @@ func newGitHub(rawURL string) (Repository, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &repository{url: rawURL, path: path, spec: &githubSpec{prBinding: "github-pr-binding", pushBinding: "github-push-binding"}}, nil
+	return &repository{url: rawURL, path: path, spec: &githubSpec{pushBinding: "github-push-binding"}}, nil
 }
 
 func proccessGitHubPath(parsedURL *url.URL) (string, error) {
@@ -43,21 +41,8 @@ func proccessGitHubPath(parsedURL *url.URL) (string, error) {
 	return path, nil
 }
 
-func (r *githubSpec) prBindingName() string {
-	return r.prBinding
-}
-
 func (r *githubSpec) pushBindingName() string {
 	return r.pushBinding
-}
-
-func (r *githubSpec) prBindingParams() []triggersv1.Param {
-	return []triggersv1.Param{
-		createBindingParam("gitref", "$(body.pull_request.head.ref)"),
-		createBindingParam("gitsha", "$(body.pull_request.head.sha)"),
-		createBindingParam("gitrepositoryurl", "$(body.repository.clone_url)"),
-		createBindingParam("fullname", "$(body.repository.full_name)"),
-	}
 }
 
 func (r *githubSpec) pushBindingParams() []triggersv1.Param {
@@ -65,15 +50,12 @@ func (r *githubSpec) pushBindingParams() []triggersv1.Param {
 		createBindingParam("gitref", "$(body.ref)"),
 		createBindingParam("gitsha", "$(body.head_commit.id)"),
 		createBindingParam("gitrepositoryurl", "$(body.repository.clone_url)"),
+		createBindingParam("fullname", "$(body.repository.full_name)"),
 	}
 }
 
-func (r *githubSpec) ciDryRunFilters() string {
-	return githubCIDryRunFilters
-}
-
-func (r *githubSpec) cdDeployFilters() string {
-	return githubCDDeployFilters
+func (r *githubSpec) pushEventFilters() string {
+	return githubPushEventFilters
 }
 
 func (r *githubSpec) eventInterceptor(secretNamespace, secretName string) *triggersv1.EventInterceptor {

--- a/pkg/pipelines/scm/gitlab_test.go
+++ b/pkg/pipelines/scm/gitlab_test.go
@@ -10,45 +10,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestPRbindingForGitlab(t *testing.T) {
-	repo, err := NewRepository("http://gitlab.com/org/test")
-	assertNoError(t, err)
-	want := triggersv1.TriggerBinding{
-		TypeMeta: triggers.TriggerBindingTypeMeta,
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "gitlab-pr-binding",
-			Namespace: "testns",
-		},
-		Spec: triggersv1.TriggerBindingSpec{
-			Params: []triggersv1.Param{
-				{
-					Name:  "gitref",
-					Value: "$(body.object_attributes.source_branch)",
-				},
-				{
-					Name:  "gitsha",
-					Value: "$(body.object_attributes.last_commit.id)",
-				},
-				{
-					Name:  "gitrepositoryurl",
-					Value: "$(body.project.git_http_url)",
-				},
-				{
-					Name:  "fullname",
-					Value: "$(body.project.path_with_namespace)",
-				},
-			},
-		},
-	}
-	got, name := repo.CreatePRBinding("testns")
-	if name != "gitlab-pr-binding" {
-		t.Fatalf("CreatePushBinding() returned a wrong binding: want %v got %v", "gitlab-pr-binding", name)
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("createPRBinding() failed:\n%s", diff)
-	}
-}
-
 func TestCreatePushBindingForGitlab(t *testing.T) {
 	repo, err := newGitLab("https://gitlab.com/org/fullname/subgroup/repository/subrepo/test")
 	assertNoError(t, err)
@@ -60,18 +21,10 @@ func TestCreatePushBindingForGitlab(t *testing.T) {
 		},
 		Spec: triggersv1.TriggerBindingSpec{
 			Params: []triggersv1.Param{
-				{
-					Name:  "gitref",
-					Value: "$(body.ref)",
-				},
-				{
-					Name:  "gitsha",
-					Value: "$(body.after)",
-				},
-				{
-					Name:  "gitrepositoryurl",
-					Value: "$(body.project.git_http_url)",
-				},
+				{Name: "gitref", Value: "$(body.ref)"},
+				{Name: "gitsha", Value: "$(body.after)"},
+				{Name: "gitrepositoryurl", Value: "$(body.project.git_http_url)"},
+				{Name: "fullname", Value: "$(body.project.path_with_namespace)"},
 			},
 		},
 	}
@@ -81,34 +34,6 @@ func TestCreatePushBindingForGitlab(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("CreatePushBinding() failed:\n%s", diff)
-	}
-}
-
-func TestCreateCITriggerForGitLab(t *testing.T) {
-	repo, err := NewRepository("http://gitlab.com/org/test")
-	assertNoError(t, err)
-	want := triggersv1.EventListenerTrigger{
-		Name: "test",
-		Bindings: []*triggersv1.EventListenerBinding{
-			{Name: "test-binding"},
-		},
-		Template: triggersv1.EventListenerTemplate{Name: "test-template"},
-		Interceptors: []*triggersv1.EventInterceptor{
-			{
-				CEL: &triggersv1.CELInterceptor{
-					Filter: fmt.Sprintf(gitlabCIDryRunFilters, "org/test"),
-				},
-			},
-			{
-				GitLab: &triggersv1.GitLabInterceptor{
-					SecretRef: &triggersv1.SecretRef{SecretKey: "webhook-secret-key", SecretName: "secret", Namespace: "ns"},
-				},
-			},
-		},
-	}
-	got := repo.CreateCITrigger("test", "secret", "ns", "test-template", []string{"test-binding"})
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("CreateCITrigger() failed:\n%s", diff)
 	}
 }
 
@@ -123,18 +48,19 @@ func TestCreateCDTriggersForGitLab(t *testing.T) {
 		Template: triggersv1.EventListenerTemplate{Name: "test-template"},
 		Interceptors: []*triggersv1.EventInterceptor{
 			{
-				CEL: &triggersv1.CELInterceptor{
-					Filter: fmt.Sprintf(gitlabCDDeployFilters, "org/test"),
-				},
-			},
-			{
 				GitLab: &triggersv1.GitLabInterceptor{
 					SecretRef: &triggersv1.SecretRef{SecretKey: "webhook-secret-key", SecretName: "secret", Namespace: "ns"},
 				},
 			},
+			{
+				CEL: &triggersv1.CELInterceptor{
+					Filter:   fmt.Sprintf(gitlabPushEventFilters, "org/test"),
+					Overlays: branchRefOverlay,
+				},
+			},
 		},
 	}
-	got := repo.CreateCDTrigger("test", "secret", "ns", "test-template", []string{"test-binding"})
+	got := repo.CreatePushTrigger("test", "secret", "ns", "test-template", []string{"test-binding"})
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Fatalf("CreateCDTrigger() failed:\n%s", diff)
 	}

--- a/pkg/pipelines/scm/interface.go
+++ b/pkg/pipelines/scm/interface.go
@@ -8,23 +8,14 @@ import (
 // implemented by repositories (Github,Gitlab,Bitbucket,etc)
 type Repository interface {
 
-	// Get Pull Request TriggerBinding name for this repository provider
-	PRBindingName() string
-
 	// Get Push TriggerBinding name for this repository provider
 	PushBindingName() string
-
-	// Create a TriggerBinding for PullRequest hooks.
-	CreatePRBinding(namespace string) (triggersv1.TriggerBinding, string)
 
 	// Create a TriggerBinding for Push Request hooks
 	CreatePushBinding(namespace string) (triggersv1.TriggerBinding, string)
 
-	// Create a CI eventlistener trigger
-	CreateCITrigger(name, secretName, secretNs, template string, bindings []string) triggersv1.EventListenerTrigger
-
-	// Create a CD eventlistener trigger
-	CreateCDTrigger(name, secretName, secretNs, template string, bindings []string) triggersv1.EventListenerTrigger
+	// Create an eventlistener trigger for Push event
+	CreatePushTrigger(name, secretName, secretNs, template string, bindings []string) triggersv1.EventListenerTrigger
 
 	// Git Repository URL
 	URL() string

--- a/pkg/pipelines/scm/utility.go
+++ b/pkg/pipelines/scm/utility.go
@@ -8,6 +8,12 @@ import (
 	triggersv1 "github.com/tektoncd/triggers/pkg/apis/triggers/v1alpha1"
 )
 
+var (
+	branchRefOverlay = []triggersv1.CELOverlay{
+		{Key: "ref", Expression: "split(body.ref,'/')[2]"},
+	}
+)
+
 // GetDriverName gets Driver name from URL
 func GetDriverName(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)
@@ -39,7 +45,8 @@ func invalidRepoURLError(repoURL, reason string) error {
 func createEventInterceptor(filter string, repoName string) *triggersv1.EventInterceptor {
 	return &triggersv1.EventInterceptor{
 		CEL: &triggersv1.CELInterceptor{
-			Filter: fmt.Sprintf(filter, repoName),
+			Filter:   fmt.Sprintf(filter, repoName),
+			Overlays: branchRefOverlay,
 		},
 	}
 }

--- a/pkg/pipelines/scm/utility_test.go
+++ b/pkg/pipelines/scm/utility_test.go
@@ -32,7 +32,8 @@ func TestCreateListenerTemplate(t *testing.T) {
 func TestCreateEventInterceptor(t *testing.T) {
 	validEventInterceptor := triggersv1.EventInterceptor{
 		CEL: &triggersv1.CELInterceptor{
-			Filter: "sampleFilter sample",
+			Filter:   "sampleFilter sample",
+			Overlays: branchRefOverlay,
 		},
 	}
 	eventInterceptor := createEventInterceptor("sampleFilter %s", "sample")

--- a/pkg/pipelines/tekton_builder.go
+++ b/pkg/pipelines/tekton_builder.go
@@ -50,7 +50,7 @@ func (tb *tektonBuilder) Service(env *config.Environment, svc *config.Service) e
 		return err
 	}
 	pipelines := getPipelines(env, svc, repo)
-	ciTrigger := repo.CreateCITrigger(triggerName(svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, pipelines.Integration.Template, pipelines.Integration.Bindings)
+	ciTrigger := repo.CreatePushTrigger(triggerName(svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, pipelines.Integration.Template, pipelines.Integration.Bindings)
 	tb.triggers = append(tb.triggers, ciTrigger)
 	return nil
 }
@@ -65,7 +65,7 @@ func createTriggersForCICD(gitOpsRepo string, cfg *config.PipelinesConfig) ([]v1
 	if err != nil {
 		return []v1alpha1.EventListenerTrigger{}, err
 	}
-	ciTrigger := repo.CreateCITrigger("ci-dryrun-from-pr", eventlisteners.GitOpsWebhookSecret, cfg.Name, "ci-dryrun-from-pr-template", []string{repo.PRBindingName()})
+	ciTrigger := repo.CreatePushTrigger("ci-dryrun-from-push", eventlisteners.GitOpsWebhookSecret, cfg.Name, "ci-dryrun-from-push-template", []string{repo.PushBindingName()})
 	triggers = append(triggers, ciTrigger)
 	return triggers, nil
 }
@@ -96,5 +96,5 @@ func clonePipelines(p *config.Pipelines) *config.Pipelines {
 }
 
 func triggerName(svc string) string {
-	return fmt.Sprintf("app-ci-build-from-pr-%s", svc)
+	return fmt.Sprintf("app-ci-build-from-push-%s", svc)
 }

--- a/pkg/pipelines/tekton_builder_test.go
+++ b/pkg/pipelines/tekton_builder_test.go
@@ -119,7 +119,7 @@ func TestGetPipelines(t *testing.T) {
 			&config.Pipelines{
 				Integration: &config.TemplateBinding{
 					Template: "app-ci-template",
-					Bindings: []string{"github-pr-binding"},
+					Bindings: []string{"github-push-binding"},
 				},
 			},
 		},
@@ -195,7 +195,7 @@ func fakeTriggers(t *testing.T, m *config.Manifest, gitOpsRepo string) []trigger
 		repo, err := scm.NewRepository(svc.SourceURL)
 		assertNoError(t, err)
 		pipelines := getPipelines(env, svc, repo)
-		devCITrigger := repo.CreateCITrigger(fmt.Sprintf("app-ci-build-from-pr-%s", svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, pipelines.Integration.Template, pipelines.Integration.Bindings)
+		devCITrigger := repo.CreatePushTrigger(fmt.Sprintf("app-ci-build-from-push-%s", svc.Name), svc.Webhook.Secret.Name, svc.Webhook.Secret.Namespace, pipelines.Integration.Template, pipelines.Integration.Bindings)
 		triggers = append(triggers, devCITrigger)
 	}
 

--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -56,10 +56,10 @@ func createCDPipelineRun(saName string) pipelinev1.PipelineRun {
 func createCIPipelineRun(saName string) pipelinev1.PipelineRun {
 	return pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-pr-pipeline-$(uid)")),
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-push-pipeline-$(uid)")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
-			PipelineRef:        createPipelineRef("ci-dryrun-from-pr-pipeline"),
+			PipelineRef:        createPipelineRef("ci-dryrun-from-push-pipeline"),
 			Resources:          createResources(),
 		},
 	}

--- a/pkg/pipelines/triggers/pipelinerun_test.go
+++ b/pkg/pipelines/triggers/pipelinerun_test.go
@@ -71,10 +71,10 @@ func TestCreateCDPipelineRun(t *testing.T) {
 func TestCreateStageCIPipelineRun(t *testing.T) {
 	validStageCIPipeline := pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-pr-pipeline-$(uid)")),
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-push-pipeline-$(uid)")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: sName,
-			PipelineRef:        createPipelineRef("ci-dryrun-from-pr-pipeline"),
+			PipelineRef:        createPipelineRef("ci-dryrun-from-push-pipeline"),
 			Resources:          createResources(),
 		},
 	}

--- a/pkg/pipelines/triggers/templates.go
+++ b/pkg/pipelines/triggers/templates.go
@@ -99,8 +99,8 @@ func CreateCDPushTemplate(ns, saName string) triggersv1.TriggerTemplate {
 func CreateCIDryRunTemplate(ns, saName string) triggersv1.TriggerTemplate {
 	return triggersv1.TriggerTemplate{
 		TypeMeta: triggerTemplateTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, "ci-dryrun-from-pr-template"),
-			statusTrackerAnnotations("ci-dryrun-from-pr-pipeline", "Stage CI Dry Run")),
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, "ci-dryrun-from-push-template"),
+			statusTrackerAnnotations("ci-dryrun-from-push-pipeline", "CI dry run on push event")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				createTemplateParamSpecDefault("gitref", "The git revision", "master"),

--- a/pkg/pipelines/triggers/templates_test.go
+++ b/pkg/pipelines/triggers/templates_test.go
@@ -128,8 +128,8 @@ func TestCreateCDPushTemplate(t *testing.T) {
 func TestCreateCIDryRunTemplate(t *testing.T) {
 	validStageCIDryRunTemplate := triggersv1.TriggerTemplate{
 		TypeMeta: triggerTemplateTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("testns", "ci-dryrun-from-pr-template"),
-			statusTrackerAnnotations("ci-dryrun-from-pr-pipeline", "Stage CI Dry Run")),
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("testns", "ci-dryrun-from-push-template"),
+			statusTrackerAnnotations("ci-dryrun-from-push-pipeline", "CI dry run on push event")),
 
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What does this PR do / why we need it**:
 Since a pull request event uses push internally, it can be replaced by a push event. The pipeline should start a new build on every merge to master.
*Changes:*
* Replacing the PR events by push will trigger the pipelines for every push to a branch (both master/non-master).
* Start a new build on a push to master in service repo
* Added a CEL expression to extract branch name
* Update unit tests
* Rename existing resources

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-200

