### PR TITLE
Gitops issue 210- Require the output directory to be empty (optionally with --overwrite)

### DIFF
--- a/pkg/odo/cli/pipelines/environment/add.go
+++ b/pkg/odo/cli/pipelines/environment/add.go
@@ -84,9 +84,9 @@ func NewCmdAddEnv(name, fullName string) *cobra.Command {
 		},
 	}
 
-	addEnvCmd.Flags().StringVar(&o.envName, "env-name", "", "name of the environment/namespace")
+	addEnvCmd.Flags().StringVar(&o.envName, "env-name", "", "Name of the environment/namespace")
 	addEnvCmd.MarkFlagRequired("env-name")
-	addEnvCmd.Flags().StringVar(&o.pipelinesFile, "pipelines-file", "pipelines.yaml", "path to pipelines file")
-	addEnvCmd.Flags().StringVar(&o.cluster, "cluster", "", "deployment cluster e.g. https://kubernetes.local.svc")
+	addEnvCmd.Flags().StringVar(&o.pipelinesFile, "pipelines-file", "pipelines.yaml", "Path to pipelines file")
+	addEnvCmd.Flags().StringVar(&o.cluster, "cluster", "", "Deployment cluster e.g. https://kubernetes.local.svc")
 	return addEnvCmd
 }

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -107,5 +107,7 @@ func addInitCommands(cmd *cobra.Command, o *pipelines.InitOptions) {
 	cmd.Flags().StringVar(&o.SealedSecretsService.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
 	cmd.Flags().StringVar(&o.SealedSecretsService.Name, "sealed-secrets-svc", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets Services that encrypts secrets")
 	cmd.Flags().StringVar(&o.StatusTrackerAccessToken, "status-tracker-access-token", "", "used to authenticate requests to push commit-statuses to your Git hosting service")
+	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "allows to overwrite if there is an exixting gitops repository")
+
 	cmd.MarkFlagRequired("gitops-repo-url")
 }

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -107,7 +107,7 @@ func addInitCommands(cmd *cobra.Command, o *pipelines.InitOptions) {
 	cmd.Flags().StringVar(&o.SealedSecretsService.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
 	cmd.Flags().StringVar(&o.SealedSecretsService.Name, "sealed-secrets-svc", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets Services that encrypts secrets")
 	cmd.Flags().StringVar(&o.StatusTrackerAccessToken, "status-tracker-access-token", "", "used to authenticate requests to push commit-statuses to your Git hosting service")
-	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "allows to overwrite if there is an existing gitops repository")
+	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "Overwrite an existing GitOps configuration")
 
 	cmd.MarkFlagRequired("gitops-repo-url")
 }

--- a/pkg/odo/cli/pipelines/init.go
+++ b/pkg/odo/cli/pipelines/init.go
@@ -107,7 +107,7 @@ func addInitCommands(cmd *cobra.Command, o *pipelines.InitOptions) {
 	cmd.Flags().StringVar(&o.SealedSecretsService.Namespace, "sealed-secrets-ns", "sealed-secrets", "namespace in which the Sealed Secrets operator is installed, automatically generated secrets are encrypted with this operator")
 	cmd.Flags().StringVar(&o.SealedSecretsService.Name, "sealed-secrets-svc", "sealedsecretcontroller-sealed-secrets", "name of the Sealed Secrets Services that encrypts secrets")
 	cmd.Flags().StringVar(&o.StatusTrackerAccessToken, "status-tracker-access-token", "", "used to authenticate requests to push commit-statuses to your Git hosting service")
-	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "allows to overwrite if there is an exixting gitops repository")
+	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "allows to overwrite if there is an existing gitops repository")
 
 	cmd.MarkFlagRequired("gitops-repo-url")
 }

--- a/pkg/odo/cli/pipelines/webhook/webhook_cmd.go
+++ b/pkg/odo/cli/pipelines/webhook/webhook_cmd.go
@@ -44,18 +44,18 @@ func (o *options) Validate() (err error) {
 func (o *options) setFlags(command *cobra.Command) {
 
 	// pipeline option
-	command.Flags().StringVar(&o.pipelinesFilePath, "pipelines-file", "pipelines.yaml", "path to pipelines file")
+	command.Flags().StringVar(&o.pipelinesFilePath, "pipelines-file", "pipelines.yaml", "Path to pipelines file")
 
 	// access-token option
-	command.Flags().StringVar(&o.accessToken, "access-token", "", "access token to be used to create Git repository webhook")
+	command.Flags().StringVar(&o.accessToken, "access-token", "", "Access token to be used to create Git repository webhook")
 	_ = command.MarkFlagRequired("access-token")
 
 	// cicd option
-	command.Flags().BoolVar(&o.isCICD, "cicd", false, "provide this flag if the target Git repository is a CI/CD configuration repository")
+	command.Flags().BoolVar(&o.isCICD, "cicd", false, "Provide this flag if the target Git repository is a CI/CD configuration repository")
 
 	// service option
-	command.Flags().StringVar(&o.serviceName, "service-name", "", "provide service name if the target Git repository is a service's source repository.")
-	command.Flags().StringVar(&o.envName, "env-name", "", "provide environment name if the target Git repository is a service's source repository.")
+	command.Flags().StringVar(&o.serviceName, "service-name", "", "Provide service name if the target Git repository is a service's source repository.")
+	command.Flags().StringVar(&o.envName, "env-name", "", "Provide environment name if the target Git repository is a service's source repository.")
 
 }
 

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -41,7 +41,8 @@ type BootstrapOptions struct {
 
 // Bootstrap bootstraps a GitOps pipelines and repository structure.
 func Bootstrap(o *BootstrapOptions, appFs afero.Fs) error {
-	exists, err := ioutils.IsExisting(appFs, o.OutputPath)
+	exists, err := ioutils.IsExisting(appFs, filepath.Join(o.OutputPath, pipelinesFile))
+	fmt.Println("This is the path", exists)
 	if exists && !o.Overwrite {
 		return fmt.Errorf("Directory already exists, cannot overwrite ( set --overwrite=true to continue )")
 	}

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/odo/pkg/pipelines/deployment"
 	"github.com/openshift/odo/pkg/pipelines/eventlisteners"
 	"github.com/openshift/odo/pkg/pipelines/imagerepo"
+	"github.com/openshift/odo/pkg/pipelines/ioutils"
 	"github.com/openshift/odo/pkg/pipelines/meta"
 	"github.com/openshift/odo/pkg/pipelines/namespaces"
 	res "github.com/openshift/odo/pkg/pipelines/resources"
@@ -40,6 +41,10 @@ type BootstrapOptions struct {
 
 // Bootstrap bootstraps a GitOps pipelines and repository structure.
 func Bootstrap(o *BootstrapOptions, appFs afero.Fs) error {
+	exists, err := ioutils.IsExisting(appFs, o.OutputPath)
+	if exists && !o.Overwrite {
+		return err
+	}
 	if o.GitOpsWebhookSecret == "" {
 		gitopsSecret, err := secrets.GenerateString(webhookSecretLength)
 		if err != nil {

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -43,7 +43,7 @@ type BootstrapOptions struct {
 func Bootstrap(o *BootstrapOptions, appFs afero.Fs) error {
 	exists, err := ioutils.IsExisting(appFs, o.OutputPath)
 	if exists && !o.Overwrite {
-		return err
+		return fmt.Errorf("Directory already exists, cannot overwrite ( set --overwrite=true to continue )")
 	}
 	if o.GitOpsWebhookSecret == "" {
 		gitopsSecret, err := secrets.GenerateString(webhookSecretLength)

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -300,7 +300,7 @@ func defaultPipelines(r scm.Repository) *config.Pipelines {
 func checkPipelinesFileExists(appFs afero.Fs, outputPath string, overWrite bool) error {
 	exists, _ := ioutils.IsExisting(appFs, filepath.Join(outputPath, pipelinesFile))
 	if exists && !overWrite {
-		return fmt.Errorf("Pipelines.yaml in output path already exists.To overwrite, please set --overwrite flag and re-run command")
+		return fmt.Errorf("pipelines.yaml in output path already exists. If you want replace your existing files, please rerun with --overwrite.")
 	}
 	return nil
 }

--- a/pkg/pipelines/bootstrap.go
+++ b/pkg/pipelines/bootstrap.go
@@ -42,7 +42,6 @@ type BootstrapOptions struct {
 // Bootstrap bootstraps a GitOps pipelines and repository structure.
 func Bootstrap(o *BootstrapOptions, appFs afero.Fs) error {
 	exists, err := ioutils.IsExisting(appFs, filepath.Join(o.OutputPath, pipelinesFile))
-	fmt.Println("This is the path", exists)
 	if exists && !o.Overwrite {
 		return fmt.Errorf("Directory already exists, cannot overwrite ( set --overwrite=true to continue )")
 	}

--- a/pkg/pipelines/bootstrap_test.go
+++ b/pkg/pipelines/bootstrap_test.go
@@ -3,7 +3,7 @@ package pipelines
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -195,7 +195,7 @@ func TestOverwriteFlag(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := Bootstrap(params, fakeFs)
-	want := fmt.Errorf("Directory already exists, cannot overwrite ( set --overwrite=true to continue )")
+	want := errors.New("Directory already exists, cannot overwrite ( set --overwrite=true to continue )")
 	if got.Error() != want.Error() {
 		t.Fatalf("Got %s want %s", got, want)
 	}

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/odo/pkg/pipelines/config"
 	"github.com/openshift/odo/pkg/pipelines/dryrun"
 	"github.com/openshift/odo/pkg/pipelines/eventlisteners"
-	"github.com/openshift/odo/pkg/pipelines/ioutils"
 	"github.com/openshift/odo/pkg/pipelines/meta"
 	"github.com/openshift/odo/pkg/pipelines/namespaces"
 	"github.com/openshift/odo/pkg/pipelines/pipelines"
@@ -110,8 +109,8 @@ const (
 
 // Init bootstraps a GitOps pipelines and repository structure.
 func Init(o *InitOptions, fs afero.Fs) error {
-	exists, err := ioutils.IsExisting(fs, o.OutputPath)
-	if exists && !o.Overwrite {
+	err := checkPipelinesFileExists(fs, o.OutputPath, o.Overwrite)
+	if err != nil {
 		return err
 	}
 	if o.GitOpsWebhookSecret == "" {

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -42,6 +42,7 @@ type InitOptions struct {
 	OutputPath               string               // Where to write the bootstrapped files to?
 	SealedSecretsService     types.NamespacedName // SealedSecrets Services name
 	StatusTrackerAccessToken string               // The auth token to use to send commit-status notifications.
+	Overwrite                bool                 //This allows to overwrite if there is an exixting gitops repository
 }
 
 // PolicyRules to be bound to service account
@@ -110,7 +111,7 @@ const (
 // Init bootstraps a GitOps pipelines and repository structure.
 func Init(o *InitOptions, fs afero.Fs) error {
 	exists, err := ioutils.IsExisting(fs, o.OutputPath)
-	if exists {
+	if exists && !o.Overwrite {
 		return err
 	}
 	if o.GitOpsWebhookSecret == "" {


### PR DESCRIPTION
**What type of PR is this?**
 /kind design

**What does does this PR do / why we need it**:
Running the command twice should fail with an appropriate error message.
Running the command twice, with --overwrite on the second case, should write the files out as normal, overwriting any pre-existing files.

Fixes #?
https://issues.redhat.com/browse/GITOPS-210

**How to test changes / Special notes to the reviewer**:
Co-authored by @gaganhegde 