### PR TITLE
Add annotations to pipelineruns

### DIFF
--- a/pkg/pipelines/triggers/pipelinerun.go
+++ b/pkg/pipelines/triggers/pipelinerun.go
@@ -26,7 +26,7 @@ func createDevCDPipelineRun(saName string) pipelinev1.PipelineRun {
 func createDevCIPipelineRun(saName string) pipelinev1.PipelineRun {
 	return pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)")),
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)"), statusTrackerAnnotations("dev-ci-build-from-pr", "CI build on push event")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
 			PipelineRef:        createPipelineRef("app-ci-pipeline"),
@@ -40,7 +40,7 @@ func createDevCIPipelineRun(saName string) pipelinev1.PipelineRun {
 				createPipelineBindingParam("COMMIT_AUTHOR", "$(params."+GitCommitAuthor+")"),
 				createPipelineBindingParam("COMMIT_MESSAGE", "$(params."+GitCommitMessage+")"),
 			},
-			Resources: createDevResource("$(params." + GitRef + ")"),
+			Resources: createDevResource("$(params." + GitCommitID + ")"),
 		},
 	}
 
@@ -61,7 +61,7 @@ func createCDPipelineRun(saName string) pipelinev1.PipelineRun {
 func createCIPipelineRun(saName string) pipelinev1.PipelineRun {
 	return pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-push-pipeline-$(uid)")),
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-push-pipeline-$(uid)"), statusTrackerAnnotations("ci-dryrun-from-push-pipeline", "CI dry run on push event")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: saName,
 			PipelineRef:        createPipelineRef("ci-dryrun-from-push-pipeline"),
@@ -102,7 +102,7 @@ func createResources() []pipelinev1.PipelineResourceBinding {
 			ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
 				Type: "git",
 				Params: []pipelinev1.ResourceParam{
-					createResourceParams("revision", "$(params."+GitRef+")"),
+					createResourceParams("revision", "$(params."+GitCommitID+")"),
 					createResourceParams("url", "$(params.gitrepositoryurl)"),
 				},
 			},

--- a/pkg/pipelines/triggers/pipelinerun_test.go
+++ b/pkg/pipelines/triggers/pipelinerun_test.go
@@ -34,7 +34,7 @@ func TestCreateDevCDPipelineRun(t *testing.T) {
 func TestCreateDevCIPipelineRun(t *testing.T) {
 	validDevCIPipelineRun := pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)")),
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "app-ci-pipeline-run-$(uid)"), statusTrackerAnnotations("dev-ci-build-from-pr", "CI build on push event")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: sName,
 			PipelineRef:        createPipelineRef("app-ci-pipeline"),
@@ -48,7 +48,7 @@ func TestCreateDevCIPipelineRun(t *testing.T) {
 				createPipelineBindingParam("COMMIT_AUTHOR", "$(params.io.openshift.build.commit.author)"),
 				createPipelineBindingParam("COMMIT_MESSAGE", "$(params.io.openshift.build.commit.message)"),
 			},
-			Resources: createDevResource("$(params.io.openshift.build.commit.ref)"),
+			Resources: createDevResource("$(params.io.openshift.build.commit.id)"),
 		},
 	}
 	template := createDevCIPipelineRun(sName)
@@ -76,7 +76,7 @@ func TestCreateCDPipelineRun(t *testing.T) {
 func TestCreateStageCIPipelineRun(t *testing.T) {
 	validStageCIPipeline := pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-push-pipeline-$(uid)")),
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("", "ci-dryrun-from-push-pipeline-$(uid)"), statusTrackerAnnotations("ci-dryrun-from-push-pipeline", "CI dry run on push event")),
 		Spec: pipelinev1.PipelineRunSpec{
 			ServiceAccountName: sName,
 			PipelineRef:        createPipelineRef("ci-dryrun-from-push-pipeline"),

--- a/pkg/pipelines/triggers/templates.go
+++ b/pkg/pipelines/triggers/templates.go
@@ -58,8 +58,7 @@ func CreateDevCIBuildPRTemplate(ns, saName string) triggersv1.TriggerTemplate {
 	return triggersv1.TriggerTemplate{
 		TypeMeta: triggerTemplateTypeMeta,
 		ObjectMeta: meta.ObjectMeta(
-			meta.NamespacedName(ns, "app-ci-template"),
-			statusTrackerAnnotations("dev-ci-build-from-pr", "Dev CI Build")),
+			meta.NamespacedName(ns, "app-ci-template")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				createTemplateParamSpec(GitRef, "The git branch for this PR."),
@@ -112,12 +111,12 @@ func CreateCDPushTemplate(ns, saName string) triggersv1.TriggerTemplate {
 // CreateCIDryRunTemplate returns TriggerTemplate for CI Dry Try
 func CreateCIDryRunTemplate(ns, saName string) triggersv1.TriggerTemplate {
 	return triggersv1.TriggerTemplate{
-		TypeMeta: triggerTemplateTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, "ci-dryrun-from-push-template"),
-			statusTrackerAnnotations("ci-dryrun-from-push-pipeline", "CI dry run on push event")),
+		TypeMeta:   triggerTemplateTypeMeta,
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName(ns, "ci-dryrun-from-push-template")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				createTemplateParamSpecDefault(GitRef, "The git revision", "master"),
+				createTemplateParamSpec(GitCommitID, "The specific commit SHA"),
 				createTemplateParamSpec("gitrepositoryurl", "The git repository url"),
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{

--- a/pkg/pipelines/triggers/templates_test.go
+++ b/pkg/pipelines/triggers/templates_test.go
@@ -49,9 +49,8 @@ func TestCreateDevCDDeployTemplate(t *testing.T) {
 
 func TestCreateDevCIBuildPRTemplate(t *testing.T) {
 	validdevCIPRTemplate := triggersv1.TriggerTemplate{
-		TypeMeta: triggerTemplateTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("testns", "app-ci-template"),
-			statusTrackerAnnotations("dev-ci-build-from-pr", "Dev CI Build")),
+		TypeMeta:   triggerTemplateTypeMeta,
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("testns", "app-ci-template")),
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
 				{
@@ -151,21 +150,14 @@ func TestCreateCDPushTemplate(t *testing.T) {
 
 func TestCreateCIDryRunTemplate(t *testing.T) {
 	validStageCIDryRunTemplate := triggersv1.TriggerTemplate{
-		TypeMeta: triggerTemplateTypeMeta,
-		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("testns", "ci-dryrun-from-push-template"),
-			statusTrackerAnnotations("ci-dryrun-from-push-pipeline", "CI dry run on push event")),
+		TypeMeta:   triggerTemplateTypeMeta,
+		ObjectMeta: meta.ObjectMeta(meta.NamespacedName("testns", "ci-dryrun-from-push-template")),
 
 		Spec: triggersv1.TriggerTemplateSpec{
 			Params: []triggersv1.ParamSpec{
-				{
-					Name:        GitRef,
-					Description: "The git revision",
-					Default:     strPtr("master"),
-				},
-				{
-					Name:        "gitrepositoryurl",
-					Description: "The git repository url",
-				},
+				{Name: GitRef, Description: "The git revision", Default: strPtr("master")},
+				{Name: "io.openshift.build.commit.id", Description: "The specific commit SHA"},
+				{Name: "gitrepositoryurl", Description: "The git repository url"},
 			},
 			ResourceTemplates: []triggersv1.TriggerResourceTemplate{
 				{


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:
The commit status tracker operator expects certain annotations in the pipelineruns
* Add the commit status tracker annotations to pipelinerun
* Replace GITREF by GITSHA since the status tracker operator expects SHA in the resource
* Add get permission for commit status tracker roles
