### PR TITLE
Kaniko build strategy to use initContainer to remote copy source.

### DIFF
--- a/pkg/devfile/adapters/common/types.go
+++ b/pkg/devfile/adapters/common/types.go
@@ -33,8 +33,8 @@ type BuildParameters struct {
 	DockerfileBytes          []byte                  // DockerfileBytes is the contents of the project Dockerfile in bytes
 	EnvSpecificInfo          envinfo.EnvSpecificInfo // EnvSpecificInfo contains infomation of env.yaml file
 	Tag                      string                  // Tag refers to the image tag of the image being built
-	DockerConfigJSONFilename string                  // Credentials refers to the path to the dockerconfig file containing external registry credentials
 	IgnoredFiles             []string                // IgnoredFiles is the list of files to not push up to a component
+	DockerConfigJSONFilename string                  // Credentials refers to the path to the dockerconfig file containing external registry credentials
 	Rootless                 bool                    // Rootless/Unprivileged builder pod
 }
 

--- a/pkg/devfile/adapters/common/utils.go
+++ b/pkg/devfile/adapters/common/utils.go
@@ -82,9 +82,6 @@ const (
 	// ShellExecutable is the shell executable
 	ShellExecutable = "/bin/sh"
 
-	// BusyboxExecutable is the buysbox executable
-	BusyboxExecutable = "/busybox/sh"
-
 	// SupervisordCtlSubCommand is the supervisord sub command ctl
 	SupervisordCtlSubCommand = "ctl"
 )

--- a/pkg/devfile/adapters/kubernetes/component/adapter.go
+++ b/pkg/devfile/adapters/kubernetes/component/adapter.go
@@ -3,7 +3,6 @@ package component
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -16,19 +15,16 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/mitchellh/go-homedir"
 	componentlabels "github.com/openshift/odo/pkg/component/labels"
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/exec"
-	"github.com/openshift/odo/pkg/secret"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	runtimeUnstructured "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/klog"
@@ -50,8 +46,6 @@ import (
 )
 
 const (
-	DeployWaitTimeout     = 60 * time.Second
-	regcredName           = "regcred"
 	DeployComponentSuffix = "-deploy"
 	BuildTimeout          = 5 * time.Minute
 )
@@ -87,161 +81,6 @@ type Adapter struct {
 }
 
 const dockerfilePath string = "Dockerfile"
-
-func (a Adapter) generateBuildContainers(containerName string, dockerfileBytes []byte, imageTag string) (corev1.Container, corev1.Container) {
-	buildImage := "gcr.io/kaniko-project/executor:latest"
-
-	command := []string{}
-	commandArgs := []string{"--dockerfile=/kaniko/build-context/Dockerfile",
-		"--context=dir:///kaniko/build-context",
-		"--destination=" + imageTag,
-		"--skip-tls-verify"}
-
-	envVars := []corev1.EnvVar{
-		{Name: "DOCKER_CONFIG", Value: "/kaniko/.docker"},
-		{Name: "AWS_ACCESS_KEY_ID", Value: "NOT_SET"},
-		{Name: "AWS_SECRET_KEY", Value: "NOT_SET"},
-	}
-
-	isPrivileged := true
-	resourceReqs := corev1.ResourceRequirements{}
-	containerKaniko := kclient.GenerateContainer(containerName, buildImage, isPrivileged, command, commandArgs, envVars, resourceReqs, nil)
-
-	containerNginx := kclient.GenerateContainer(containerName+"-nginx",
-		//"busybox",
-		"nginx",
-		// "ubuntu",
-		true, // isPrivileged
-		[]string{},
-		//		[]string{"while true; do echo \"x\"; sleep 5; done"},
-		// []string{"while true; do sleep 1; if [ -f /tmp/complete ]; then break; fi done"},
-		[]string{}, // command args
-		[]corev1.EnvVar{}, corev1.ResourceRequirements{},
-		nil) // ports
-
-	containerKaniko.VolumeMounts = []corev1.VolumeMount{
-		//		{Name: "destination", MountPath: "/data"},
-		{Name: "build-context", MountPath: "/kaniko/build-context"},
-		{Name: "kaniko-secret", MountPath: "/kaniko/.docker"},
-	}
-
-	containerNginx.VolumeMounts = []corev1.VolumeMount{
-		{Name: "build-context", MountPath: "/kaniko/build-context"},
-	}
-
-	/*
-		if container.SecurityContext == nil {
-			container.SecurityContext = &corev1.SecurityContext{}
-		}
-	*/
-	// priv := true
-	// container.SecurityContext.Privileged = &priv
-	return *containerKaniko, *containerNginx
-}
-
-// func (a Adapter) generateInitContainer(initContainerName string) corev1.Container {
-
-// 	//initImage := "ubuntu"
-// 	//command := []string{}
-// 	//commandArgs := []string{"/bin/sh", "-c", "while true; do sleep 1"}
-// 	// commandArgs := []string{}
-// 	//isPrivileged := false
-// 	//envVars := []corev1.EnvVar{}
-// 	//resourceReqs := corev1.ResourceRequirements{}
-
-// 	container := kclient.GenerateContainer(initContainerName,
-// 		//"busybox",
-// 		"ngnix",
-// 		true, // privileged
-// 		//		[]string{"while true; do echo \"x\"; sleep 5; done"},
-// 		[]string{}, // comand
-// 		[]string{}, // comand args
-
-// 		[]corev1.EnvVar{}, corev1.ResourceRequirements{},
-// 		nil) // ports
-
-// 	/*
-// 		container.VolumeMounts = []corev1.VolumeMount{
-// 			{Name: "source", MountPath: "/src"},
-// 			{Name: "destination", MountPath: "/dst"},
-// 		}
-// 	*/
-
-// 	return *container
-// }
-
-func (a Adapter) createBuildDeployment(labels map[string]string, containerKaniko, containerNginx corev1.Container) (err error) {
-
-	objectMeta := kclient.CreateObjectMeta(a.ComponentName, a.Client.Namespace, labels, nil)
-	podTemplateSpec := kclient.GeneratePodTemplateSpec(objectMeta, []corev1.Container{containerNginx, containerKaniko})
-	//hostPathType := corev1.HostPathDirectoryOrCreate
-	//hostPathType := corev1.HostPathFileOrCreate
-
-	// podTemplateSpec := &corev1.PodTemplateSpec{
-	// 	ObjectMeta: objectMeta,
-	// 	Spec: corev1.PodSpec{
-	// 		// InitContainers: []corev1.Container{initContainer},
-	// 		Containers: []corev1.Container{containerNginx, containerKaniko},
-	// 		Volumes: []corev1.Volume{
-	// 			{Name: "kaniko-secret",
-	// 				VolumeSource: corev1.VolumeSource{
-	// 					Secret: &corev1.SecretVolumeSource{
-	// 						SecretName: regcredName,
-	// 						Items: []corev1.KeyToPath{
-	// 							{
-	// 								Key:  ".dockerconfigjson",
-	// 								Path: "config.json",
-	// 							},
-	// 						},
-	// 					},
-	// 				},
-	// 			},
-	// 			{Name: "build-context",
-	// 				VolumeSource: corev1.VolumeSource{
-	// 					EmptyDir: &corev1.EmptyDirVolumeSource{},
-	// 				},
-	// 			},
-	// 		},
-	// 	},
-	// }
-
-	buildContextVolume := corev1.Volume{
-		Name: "build-context",
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
-	}
-
-	kanikoSecretVolume := corev1.Volume{
-		Name: "kaniko-secret",
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: regcredName,
-				Items: []corev1.KeyToPath{
-					{
-						Key:  ".dockerconfigjson",
-						Path: "config.json",
-					},
-				},
-			},
-		},
-	}
-
-	podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, buildContextVolume)
-	podTemplateSpec.Spec.Volumes = append(podTemplateSpec.Spec.Volumes, kanikoSecretVolume)
-
-	deploymentSpec := kclient.GenerateDeploymentSpec(*podTemplateSpec, labels)
-	klog.V(3).Infof("Creating deployment %v", deploymentSpec.Template.GetName())
-	_, err = a.Client.CreateDeployment(*deploymentSpec)
-	if err != nil {
-		return err
-	}
-	klog.V(5).Infof("Successfully created component %v", deploymentSpec.Template.GetName())
-	// ownerReference := kclient.GenerateOwnerReference(deployment)
-	// objectMetaTemp := objectMeta
-	// objectMetaTemp.OwnerReferences = append(objectMeta.OwnerReferences, ownerReference)
-	return nil
-}
 
 func (a Adapter) runBuildConfig(client *occlient.Client, parameters common.BuildParameters) (err error) {
 	buildName := a.ComponentName
@@ -360,136 +199,8 @@ func (a Adapter) Build(parameters common.BuildParameters) (err error) {
 	if isBuildConfigSupported && !parameters.Rootless {
 		return a.runBuildConfig(client, parameters)
 	} else {
-		// perform kaniko build
-		err := a.BuildWithKaniko(parameters)
-		if err != nil {
-			return err
-		}
-		return nil
+		return a.runKaniko(parameters)
 	}
-}
-
-func (a Adapter) BuildWithKaniko(parameters common.BuildParameters) (err error) {
-
-	NamespacedName := types.NamespacedName{
-		Name:      regcredName,
-		Namespace: parameters.EnvSpecificInfo.GetNamespace(),
-	}
-
-	authJSONPath, err := homedir.Expand(parameters.DockerConfigJSONFilename)
-	if err != nil {
-		return fmt.Errorf("failed to generate path to file: %v", err)
-	}
-
-	f, err := os.Open(authJSONPath)
-	if err != nil {
-		return fmt.Errorf("failed to read Docker config %#v : %s", authJSONPath, err)
-	}
-	defer f.Close()
-
-	dockerSecret, err := secret.CreateDockerConfigSecret(NamespacedName, f)
-	if err != nil {
-		return err
-	}
-
-	gvk := schema.GroupVersionKind{
-		Group:   "",
-		Version: "v1",
-		Kind:    "Secret",
-	}
-
-	gvr := schema.GroupVersionResource{Group: gvk.Group, Version: gvk.Version, Resource: strings.ToLower(gvk.Kind + "s")}
-	dockerSecretMap, err := runtimeUnstructured.DefaultUnstructuredConverter.ToUnstructured(dockerSecret)
-	dockerSecretByteArray, err := json.Marshal(dockerSecretMap)
-	var dockerSecretUnstructured *unstructured.Unstructured
-	err = json.Unmarshal(dockerSecretByteArray, &dockerSecretUnstructured)
-	if err != nil {
-		return err
-	}
-	_, err = a.Client.DynamicClient.Resource(gvr).Namespace(NamespacedName.Namespace).Create(dockerSecretUnstructured, metav1.CreateOptions{})
-
-	if err != nil {
-		if errors.Cause(err).Error() != "secrets \""+regcredName+"\" already exists" {
-			return err
-		}
-	}
-
-	containerName := a.ComponentName + "-kaniko-build-container"
-	buildContainer, fileTransferContainer := a.generateBuildContainers(containerName, parameters.DockerfileBytes, parameters.Tag)
-	labels := map[string]string{
-		"component": a.ComponentName,
-	}
-
-	err = a.createBuildDeployment(labels, buildContainer, fileTransferContainer)
-	if err != nil {
-		return errors.Wrap(err, "error while creating kaniko deployment")
-	}
-
-	// Delete deployment
-
-	defer func() {
-		// derr := a.Delete(labels)
-		// if err == nil {
-		// 	err = errors.Wrapf(derr, "failed to delete build step for component with name: %s", a.ComponentName)
-		// }
-
-		// rerr := os.Remove(parameters.DockerfilePath)
-		// if err == nil {
-		// 	err = errors.Wrapf(rerr, "failed to delete %s", parameters.DockerfilePath)
-		// }
-	}()
-
-	// _, err = a.Client.WaitForDeploymentRollout(a.ComponentName)
-	// if err != nil {
-	// 	return errors.Wrap(err, "error while waiting for deployment rollout")
-	// }
-
-	// Wait for Pod to be in running state otherwise we can't sync data or exec commands to it.
-	pod, err := a.waitAndGetComponentPod(true)
-	if err != nil {
-		return errors.Wrapf(err, "unable to get pod for component %s", a.ComponentName)
-	}
-
-	// podSelector := fmt.Sprintf("component=%s", a.ComponentName)
-	// watchOptions := metav1.ListOptions{
-	// 	LabelSelector: podSelector,
-	// }
-
-	// // pod, err := a.Client.WaitAndGetPod(watchOptions, corev1.PodPending, "Waiting for component to start in waitAndGetComponentPod", false)
-	// pod, err := a.Client.WaitAndGetPod(watchOptions, corev1.PodRunning, "Waiting for component to start in waitAndGetComponentPod", false)
-
-	// if err != nil {
-	// 	return errors.Wrapf(err, "error while waiting for pod %s", podSelector)
-	// }
-
-	// Need to wait for container to start
-	time.Sleep(5 * time.Second)
-
-	// Sync files to volume
-	log.Infof("\nSyncing to component %s", a.ComponentName)
-	// Get a sync adapter. Check if project files have changed and sync accordingly
-	syncAdapter := sync.New(a.AdapterContext, &a.Client)
-	compInfo := common.ComponentInfo{
-		//ContainerName: containerName,
-		ContainerName: containerName + "-nginx",
-		PodName:       pod.GetName(),
-	}
-
-	syncFolder, err := syncAdapter.SyncFilesBuild(parameters, dockerfilePath)
-
-	if err != nil {
-		return errors.Wrapf(err, "failed to sync to component with name %s", a.ComponentName)
-	}
-
-	destinationDirectory := "/kaniko/build-context"
-	klog.V(4).Infof("Copying files to pod")
-	err = a.Client.ExtractProjectToComponent(compInfo, destinationDirectory, syncFolder)
-	if err != nil {
-		return errors.Wrapf(err, "failed to stream tarball into file transfer container")
-	}
-
-	return
-
 }
 
 // Perform the substitutions in the manifest file(s)
@@ -1031,7 +742,7 @@ func (a Adapter) waitAndGetComponentPod(hideSpinner bool) (*corev1.Pod, error) {
 		LabelSelector: podSelector,
 	}
 	// Wait for Pod to be in running state otherwise we can't sync data to it.
-	pod, err := a.Client.WaitAndGetPod(watchOptions, corev1.PodRunning, "Waiting for component to start in waitAndGetComponentPod", hideSpinner)
+	pod, err := a.Client.WaitAndGetPod(watchOptions, corev1.PodRunning, "Waiting for component to start", hideSpinner)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while waiting for pod %s", podSelector)
 	}

--- a/pkg/devfile/adapters/kubernetes/component/kaniko_build.go
+++ b/pkg/devfile/adapters/kubernetes/component/kaniko_build.go
@@ -102,7 +102,7 @@ func (a Adapter) createKanikoBuilderPod(labels map[string]string, init, builder 
 	pod := &corev1.Pod{
 		ObjectMeta: objectMeta,
 		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyOnFailure,
+			RestartPolicy: corev1.RestartPolicyNever,
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsUser: &defaultId,
 			},

--- a/pkg/devfile/adapters/kubernetes/component/kaniko_build.go
+++ b/pkg/devfile/adapters/kubernetes/component/kaniko_build.go
@@ -1,0 +1,227 @@
+package component
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/openshift/odo/pkg/devfile/adapters/common"
+	"github.com/openshift/odo/pkg/kclient"
+	"github.com/openshift/odo/pkg/log"
+	"github.com/openshift/odo/pkg/secret"
+	"github.com/openshift/odo/pkg/sync"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	runtimeUnstructured "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+)
+
+const (
+	regcredName           = "regcred"
+	kanikoSecret          = "kaniko-secret"
+	buildContext          = "build-context"
+	buildContextMountPath = "/root/build-context"
+	kanikoSecretMountPath = "/root/.docker"
+	completionFile        = "/tmp/complete"
+)
+
+var (
+	buildContextVolumeMount = corev1.VolumeMount{Name: buildContext, MountPath: buildContextMountPath}
+	kanikoSecretVolumeMount = corev1.VolumeMount{Name: kanikoSecret, MountPath: kanikoSecretMountPath}
+
+	secretGroupVersionResource = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	defaultId                  = int64(0)
+)
+
+func (a Adapter) runKaniko(parameters common.BuildParameters) error {
+	if err := a.createSecret(parameters.EnvSpecificInfo.GetNamespace(), parameters.DockerConfigJSONFilename); err != nil {
+		return err
+	}
+	containerName := "build"
+	initContainerName := "init"
+	labels := map[string]string{
+		"component": a.ComponentName,
+	}
+
+	if err := a.createKanikoBuilderPod(labels, initContainer(initContainerName), builderContainer(containerName, parameters.Tag)); err != nil {
+		return errors.Wrap(err, "error while creating kaniko builder pod")
+	}
+
+	podSelector := fmt.Sprintf("component=%s", a.ComponentName)
+	watchOptions := metav1.ListOptions{
+		LabelSelector: podSelector,
+	}
+	// Wait for Pod to be in running state otherwise we can't sync data to it.
+	pod, err := a.Client.WaitAndGetPodOnInitContainerStarted(watchOptions, initContainerName, "Waiting for component to start", false)
+	if err != nil {
+		return errors.Wrapf(err, "error while waiting for pod %s", podSelector)
+	}
+
+	// Sync files to volume
+	log.Infof("\nSyncing to component %s", a.ComponentName)
+	// Get a sync adapter. Check if project files have changed and sync accordingly
+	syncAdapter := sync.New(a.AdapterContext, &a.Client)
+	compInfo := common.ComponentInfo{
+		ContainerName: initContainerName,
+		PodName:       pod.GetName(),
+	}
+
+	syncFolder, err := syncAdapter.SyncFilesBuild(parameters, dockerfilePath)
+
+	if err != nil {
+		return errors.Wrapf(err, "failed to sync to component with name %s", a.ComponentName)
+	}
+
+	klog.V(4).Infof("Copying files to pod")
+	if err := a.Client.ExtractProjectToComponent(compInfo, buildContextMountPath, syncFolder); err != nil {
+		return errors.Wrapf(err, "failed to stream tarball into file transfer container")
+	}
+
+	cmd := []string{"touch", completionFile}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := a.Client.ExecCMDInContainer(compInfo, cmd, &stdout, &stderr, nil, false); err != nil {
+		log.Errorf("Command '%s' in container failed.\n", strings.Join(cmd, " "))
+		log.Errorf("stdout: %s\n", stdout.String())
+		log.Errorf("stderr: %s\n", stderr.String())
+		log.Errorf("err: %s\n", err.Error())
+		return err
+	}
+	return errors.New("WIP: Need to redirect log output the stdout and wait for build to complete")
+}
+
+func (a Adapter) createKanikoBuilderPod(labels map[string]string, init, builder *corev1.Container) error {
+	objectMeta := kclient.CreateObjectMeta(a.ComponentName, a.Client.Namespace, labels, nil)
+	pod := &corev1.Pod{
+		ObjectMeta: objectMeta,
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyOnFailure,
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser: &defaultId,
+			},
+			InitContainers: []corev1.Container{*init},
+			Containers:     []corev1.Container{*builder},
+			Volumes: []corev1.Volume{
+				{Name: kanikoSecret,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: regcredName,
+							Items: []corev1.KeyToPath{
+								{
+									Key:  ".dockerconfigjson",
+									Path: "config.json",
+								},
+							},
+						},
+					},
+				},
+				{Name: buildContext,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+		},
+	}
+
+	klog.V(3).Infof("Creating build pod %v", pod.GetName())
+	p, err := a.Client.KubeClient.CoreV1().Pods(a.Client.Namespace).Create(pod)
+	if err != nil {
+		return err
+	}
+	klog.V(5).Infof("Successfully created pod %v", p.GetName())
+	return nil
+}
+
+func builderContainer(name, imageTag string) *corev1.Container {
+	commandArgs := []string{"--dockerfile=" + buildContextMountPath + "/Dockerfile",
+		"--context=dir://" + buildContextMountPath,
+		"--destination=" + imageTag}
+	envVars := []corev1.EnvVar{
+		{Name: "DOCKER_CONFIG", Value: kanikoSecretMountPath},
+		{Name: "AWS_ACCESS_KEY_ID", Value: "NOT_SET"},
+		{Name: "AWS_SECRET_KEY", Value: "NOT_SET"},
+	}
+	container := &corev1.Container{
+		Name:  name,
+		Image: "gcr.io/kaniko-project/executor:latest",
+
+		ImagePullPolicy: corev1.PullAlways,
+		Resources:       corev1.ResourceRequirements{},
+		Env:             envVars,
+		Command:         []string{},
+		Args:            commandArgs,
+		VolumeMounts: []corev1.VolumeMount{
+			buildContextVolumeMount,
+			kanikoSecretVolumeMount,
+		},
+	}
+	return container
+}
+
+func initContainer(name string) *corev1.Container {
+	return &corev1.Container{
+		Name:            name,
+		Image:           "busybox",
+		ImagePullPolicy: corev1.PullAlways,
+		Resources:       corev1.ResourceRequirements{},
+		Env:             []corev1.EnvVar{},
+		Command:         []string{"/bin/sh", "-c"},
+		Args:            []string{"while true; do sleep 1; if [ -f " + completionFile + " ]; then break; fi done"},
+		VolumeMounts: []corev1.VolumeMount{
+			buildContextVolumeMount,
+		},
+	}
+}
+
+func (a Adapter) createSecret(ns, dcokerConfigFile string) error {
+	filename, err := homedir.Expand(dcokerConfigFile)
+	if err != nil {
+		return fmt.Errorf("failed to generate path to file for %s: %v", dcokerConfigFile, err)
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return fmt.Errorf("failed to read Docker config %#v : %s", filename, err)
+	}
+	defer f.Close()
+
+	secret, err := secret.CreateDockerConfigSecret(types.NamespacedName{
+		Name:      regcredName,
+		Namespace: ns,
+	}, f)
+	if err != nil {
+		return err
+	}
+
+	secretData, err := runtimeUnstructured.DefaultUnstructuredConverter.ToUnstructured(secret)
+	if err != nil {
+		return err
+	}
+
+	secretBytes, err := json.Marshal(secretData)
+	if err != nil {
+		return err
+	}
+
+	var secretUnstructured *unstructured.Unstructured
+	if err := json.Unmarshal(secretBytes, &secretUnstructured); err != nil {
+		return err
+	}
+
+	if _, err = a.Client.DynamicClient.Resource(secretGroupVersionResource).
+		Namespace(ns).
+		Create(secretUnstructured, metav1.CreateOptions{}); err != nil {
+		if errors.Cause(err).Error() != "secrets \""+regcredName+"\" already exists" {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/kclient/deployments.go
+++ b/pkg/kclient/deployments.go
@@ -53,7 +53,7 @@ func (c *Client) ListDeployments(selector string) (*appsv1.DeploymentList, error
 // WaitForDeploymentRollout waits for deployment to finish rollout. Returns the state of the deployment after rollout.
 func (c *Client) WaitForDeploymentRollout(deploymentName string) (*appsv1.Deployment, error) {
 	klog.V(4).Infof("Waiting for %s deployment rollout", deploymentName)
-	s := log.Spinner("Waiting for component to start in WaitForDeploymentRollout")
+	s := log.Spinner("Waiting for component to start")
 	defer s.End(false)
 
 	w, err := c.KubeClient.AppsV1().Deployments(c.Namespace).Watch(metav1.ListOptions{FieldSelector: "metadata.name=" + deploymentName})

--- a/pkg/odo/cli/component/deploy.go
+++ b/pkg/odo/cli/component/deploy.go
@@ -45,10 +45,10 @@ type DeployOptions struct {
 	DockerfileBytes          []byte
 	namespace                string
 	tag                      string
-	dockerConfigJSONFilename string
 	ManifestSource           []byte
 	DeploymentPort           int
-	Rootless                 bool
+	dockerConfigJSONFilename string
+	rootless                 bool
 
 	*genericclioptions.Context
 }
@@ -112,7 +112,7 @@ func (do *DeployOptions) Validate() (err error) {
 	for _, component := range components {
 		if component.Dockerfile != nil {
 			dockerfileURL = component.Dockerfile.DockerfileLocation
-			do.Rootless = component.Dockerfile.Rootless
+			do.rootless = component.Dockerfile.Rootless
 			break
 		}
 	}

--- a/pkg/odo/cli/component/devfile.go
+++ b/pkg/odo/cli/component/devfile.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/openshift/odo/pkg/devfile"
 	"github.com/openshift/odo/pkg/devfile/adapters"
@@ -166,10 +165,10 @@ func (do *DeployOptions) DevfileDeploy() (err error) {
 	buildParams := common.BuildParameters{
 		Path:                     do.sourcePath,
 		Tag:                      do.tag,
-		DockerConfigJSONFilename: do.dockerConfigJSONFilename,
 		DockerfileBytes:          do.DockerfileBytes,
-		Rootless:                 do.Rootless,
 		EnvSpecificInfo:          *do.EnvSpecificInfo,
+		DockerConfigJSONFilename: do.dockerConfigJSONFilename,
+		Rootless:                 do.rootless,
 	}
 
 	log.Infof("\nBuilding component %s", componentName)
@@ -183,8 +182,6 @@ func (do *DeployOptions) DevfileDeploy() (err error) {
 		)
 		os.Exit(1)
 	}
-
-	time.Sleep(5 * time.Second)
 
 	deployParams := common.DeployParameters{
 		EnvSpecificInfo: *do.EnvSpecificInfo,


### PR DESCRIPTION
* moved kaniko build functions to kaniko_build.go to make merge easier.
* kaniko builder pod to use initContainer to remote copy/untar source to build-context
* add a method to wait for initContext to start before start remote copying.
* runAsUser(0) to workaround  permission access issue with Kaniko executer build image.
* Create pod instead of deployment and set restartPolicy to never.

**What type of PR is this?**
> Uncomment only one ` /kind` line, and delete the rest.
> For example, `> /kind bug` would simply become: `/kind bug`

> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind failing-test
> /kind feature
> /kind flake
> /kind code-refactoring
>
> Documentation changes: Please include [skip ci] in your commit message as well
> /kind documentation
> [skip ci]

**What does does this PR do / why we need it**:

**Have you updated the necessary documentation?**

See https://github.com/rhd-gitops-example/docs

[ ] Updated

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**:
