### PR TITLE
Add external registry support for BuildConfig builds in odo deploy

### DIFF
--- a/pkg/devfile/adapters/kubernetes/component/kaniko_build.go
+++ b/pkg/devfile/adapters/kubernetes/component/kaniko_build.go
@@ -1,28 +1,23 @@
 package component
 
 import (
-	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/signal"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
+	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes/utils"
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/log"
-	"github.com/openshift/odo/pkg/secret"
 	"github.com/openshift/odo/pkg/sync"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	runtimeUnstructured "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 )
 
@@ -44,9 +39,20 @@ var (
 )
 
 func (a Adapter) runKaniko(parameters common.BuildParameters) error {
-	if err := a.createSecret(parameters.EnvSpecificInfo.GetNamespace(), parameters.DockerConfigJSONFilename); err != nil {
+	var secretUnstructured *unstructured.Unstructured
+	var err error
+	if secretUnstructured, err = utils.CreateSecret(regcredName, parameters.EnvSpecificInfo.GetNamespace(), parameters.DockerConfigJSONFilename); err != nil {
 		return err
 	}
+
+	if _, err := a.Client.DynamicClient.Resource(secretGroupVersionResource).
+		Namespace(parameters.EnvSpecificInfo.GetNamespace()).
+		Create(secretUnstructured, metav1.CreateOptions{}); err != nil {
+		if errors.Cause(err).Error() != "secrets \""+regcredName+"\" already exists" {
+			return err
+		}
+	}
+
 	containerName := "build"
 	initContainerName := "init"
 	labels := map[string]string{
@@ -105,38 +111,10 @@ func (a Adapter) runKaniko(parameters common.BuildParameters) error {
 	controlC := make(chan os.Signal, 1)
 
 	var cmdOutput string
-	// This Go routine will automatically pipe the output from WaitForBuildToFinish to
-	// our logger.
-	// We pass the controlC os.Signal in order to output the logs within the terminateBuild
-	// function if the process is interrupted by the user performing a ^C. If we didn't pass it
-	// The Scanner would consume the log, and only output it if there was an err within this
-	// func.
-	go func(controlC chan os.Signal) {
-		select {
-		case <-controlC:
-			return
-		default:
-			scanner := bufio.NewScanner(reader)
-			for scanner.Scan() {
-				line := scanner.Text()
 
-				if log.IsDebug() {
-					_, err := fmt.Fprintln(os.Stdout, line)
-					if err != nil {
-						log.Errorf("Unable to print to stdout: %v", err)
-					}
-				}
-
-				cmdOutput += fmt.Sprintln(line)
-			}
-		}
-	}(controlC)
+	go utils.PipeStdOutput(cmdOutput, reader, controlC)
 
 	s := log.Spinner("Waiting for builder pod to complete")
-	// if err := client.WaitForBuildToFinish(bc.Name, writer, BuildTimeout); err != nil {
-	// 	s.End(false)
-	// 	return errors.Wrapf(err, "unable to build image using BuildConfig %s, error: %s", buildName, cmdOutput)
-	// }
 
 	if _, err := a.Client.WaitAndGetPod(watchOptions, corev1.PodSucceeded, "Waiting for builder pod to complete", false); err != nil {
 		s.End(false)
@@ -232,49 +210,4 @@ func initContainer(name string) *corev1.Container {
 			buildContextVolumeMount,
 		},
 	}
-}
-
-func (a Adapter) createSecret(ns, dcokerConfigFile string) error {
-	filename, err := homedir.Expand(dcokerConfigFile)
-	if err != nil {
-		return fmt.Errorf("failed to generate path to file for %s: %v", dcokerConfigFile, err)
-	}
-
-	f, err := os.Open(filename)
-	if err != nil {
-		return fmt.Errorf("failed to read Docker config %#v : %s", filename, err)
-	}
-	defer f.Close()
-
-	secret, err := secret.CreateDockerConfigSecret(types.NamespacedName{
-		Name:      regcredName,
-		Namespace: ns,
-	}, f)
-	if err != nil {
-		return err
-	}
-
-	secretData, err := runtimeUnstructured.DefaultUnstructuredConverter.ToUnstructured(secret)
-	if err != nil {
-		return err
-	}
-
-	secretBytes, err := json.Marshal(secretData)
-	if err != nil {
-		return err
-	}
-
-	var secretUnstructured *unstructured.Unstructured
-	if err := json.Unmarshal(secretBytes, &secretUnstructured); err != nil {
-		return err
-	}
-
-	if _, err = a.Client.DynamicClient.Resource(secretGroupVersionResource).
-		Namespace(ns).
-		Create(secretUnstructured, metav1.CreateOptions{}); err != nil {
-		if errors.Cause(err).Error() != "secrets \""+regcredName+"\" already exists" {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/devfile/adapters/kubernetes/component/kaniko_build.go
+++ b/pkg/devfile/adapters/kubernetes/component/kaniko_build.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/openshift/odo/pkg/devfile/adapters/common"
 	"github.com/openshift/odo/pkg/devfile/adapters/kubernetes/utils"
 	"github.com/openshift/odo/pkg/kclient"
@@ -46,20 +44,10 @@ func (a Adapter) runKaniko(parameters common.BuildParameters, destinationImageRe
 	var err error
 
 	if destinationImageRegistry == "external" {
-		filename, err := homedir.Expand(parameters.DockerConfigJSONFilename)
+		data, err := utils.CreateDockerConfigDataFromFilepath(parameters.DockerConfigJSONFilename)
 		if err != nil {
-			return fmt.Errorf("failed to generate path to file for %s: %v", parameters.DockerConfigJSONFilename, err)
+			return err
 		}
-
-		f, err := os.Open(filename)
-		if err != nil {
-			return fmt.Errorf("failed to read Docker config %#v : %s", filename, err)
-		}
-		data, err := ioutil.ReadAll(f)
-		if err != nil {
-			return fmt.Errorf("failed to read secret data: %v", err)
-		}
-		defer f.Close()
 
 		if secretUnstructured, err = utils.CreateSecret(regcredName, parameters.EnvSpecificInfo.GetNamespace(), data); err != nil {
 			return err

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
 
 	// "context"
+	"github.com/mitchellh/go-homedir"
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
@@ -357,6 +359,24 @@ func PipeStdOutput(cmdOutput string, reader *io.PipeReader, controlC chan os.Sig
 			cmdOutput += fmt.Sprintln(line)
 		}
 	}
+}
+
+func CreateDockerConfigDataFromFilepath(DockerConfigJSONFilename string) ([]byte, error) {
+	filename, err := homedir.Expand(DockerConfigJSONFilename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate path to file for %s: %v", DockerConfigJSONFilename, err)
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Docker config %#v : %s", filename, err)
+	}
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read secret data: %v", err)
+	}
+	defer f.Close()
+	return data, nil
 }
 
 func CreateSecret(regcredName string, ns string, dockerConfigData []byte) (*unstructured.Unstructured, error) {

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -2,14 +2,14 @@ package utils
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 
-	"encoding/json"
-
+	// "context"
 	adaptersCommon "github.com/openshift/odo/pkg/devfile/adapters/common"
 
 	devfileParser "github.com/openshift/odo/pkg/devfile/parser"
@@ -17,14 +17,14 @@ import (
 	"github.com/openshift/odo/pkg/envinfo"
 	"github.com/openshift/odo/pkg/kclient"
 	"github.com/openshift/odo/pkg/log"
-	"github.com/openshift/odo/pkg/util"
-
-	"github.com/mitchellh/go-homedir"
 	"github.com/openshift/odo/pkg/secret"
+	"github.com/openshift/odo/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	// "sigs.k8s.io/controller-runtime/pkg/client"
 	runtimeUnstructured "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
@@ -359,22 +359,12 @@ func PipeStdOutput(cmdOutput string, reader *io.PipeReader, controlC chan os.Sig
 	}
 }
 
-func CreateSecret(regcredName string, ns, dcokerConfigFile string) (*unstructured.Unstructured, error) {
-	filename, err := homedir.Expand(dcokerConfigFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate path to file for %s: %v", dcokerConfigFile, err)
-	}
-
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read Docker config %#v : %s", filename, err)
-	}
-	defer f.Close()
+func CreateSecret(regcredName string, ns string, dockerConfigData []byte) (*unstructured.Unstructured, error) {
 
 	secret, err := secret.CreateDockerConfigSecret(types.NamespacedName{
 		Name:      regcredName,
 		Namespace: ns,
-	}, f)
+	}, dockerConfigData)
 	if err != nil {
 		return nil, err
 	}
@@ -396,3 +386,15 @@ func CreateSecret(regcredName string, ns, dcokerConfigFile string) (*unstructure
 
 	return secretUnstructured, nil
 }
+
+// func getSA(ns *corev1.Namespace) (*corev1.ServiceAccount, error) {
+
+// 	log.Info("finding sa", "sa", "builder", "ns", ns.Name)
+// 	sa := &corev1.ServiceAccount{}
+// 	saType := types.NamespacedName{Name: "builder", Namespace: ns.Name}
+// 	if err := client.Client.Get(context.TODO(), saType, sa); err == nil {
+// 		return sa, err
+// 	} else {
+// 		return nil, err
+// 	}
+// }

--- a/pkg/devfile/adapters/kubernetes/utils/utils.go
+++ b/pkg/devfile/adapters/kubernetes/utils/utils.go
@@ -406,15 +406,3 @@ func CreateSecret(regcredName string, ns string, dockerConfigData []byte) (*unst
 
 	return secretUnstructured, nil
 }
-
-// func getSA(ns *corev1.Namespace) (*corev1.ServiceAccount, error) {
-
-// 	log.Info("finding sa", "sa", "builder", "ns", ns.Name)
-// 	sa := &corev1.ServiceAccount{}
-// 	saType := types.NamespacedName{Name: "builder", Namespace: ns.Name}
-// 	if err := client.Client.Get(context.TODO(), saType, sa); err == nil {
-// 		return sa, err
-// 	} else {
-// 		return nil, err
-// 	}
-// }

--- a/pkg/occlient/occlient.go
+++ b/pkg/occlient/occlient.go
@@ -3130,7 +3130,7 @@ func (c *Client) GetPVCFromName(pvcName string) (*corev1.PersistentVolumeClaim, 
 // as input a binary which contains a dockerfile at a specific location. It will build
 // the source with Dockerfile, and push the image using tag.
 // envVars is the array containing the environment variables
-func (c *Client) CreateDockerBuildConfigWithBinaryInput(commonObjectMeta metav1.ObjectMeta, dockerfilePath string, outputImageTag string, envVars []corev1.EnvVar, outputType string) (bc buildv1.BuildConfig, err error) {
+func (c *Client) CreateDockerBuildConfigWithBinaryInput(commonObjectMeta metav1.ObjectMeta, dockerfilePath string, outputImageTag string, envVars []corev1.EnvVar, outputType string, secretName string) (bc buildv1.BuildConfig, err error) {
 	// generate and create ImageStream if not present
 
 	var imageStream *imagev1.ImageStream
@@ -3146,6 +3146,12 @@ func (c *Client) CreateDockerBuildConfigWithBinaryInput(commonObjectMeta metav1.
 	}
 
 	bc = generateDockerBuildConfigWithBinaryInput(commonObjectMeta, dockerfilePath, outputImageTag, outputType)
+
+	if secretName != "" {
+		bc.Spec.CommonSpec.Output.PushSecret = &corev1.LocalObjectReference{
+			Name: secretName,
+		}
+	}
 
 	if len(envVars) > 0 {
 		bc.Spec.Strategy.SourceStrategy.Env = envVars

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -2,8 +2,6 @@ package secret
 
 import (
 	"fmt"
-	"io"
-	"io/ioutil"
 
 	"strings"
 
@@ -84,21 +82,18 @@ func availablePorts(secrets []corev1.Secret) []string {
 	return ports
 }
 
-func CreateDockerConfigSecret(name types.NamespacedName, in io.Reader) (*corev1.Secret, error) {
-	return createSecret(name, ".dockerconfigjson", corev1.SecretTypeDockerConfigJson, in)
+func CreateDockerConfigSecret(name types.NamespacedName, dockerConfigData []byte) (*corev1.Secret, error) {
+	return createSecret(name, ".dockerconfigjson", corev1.SecretTypeDockerConfigJson, dockerConfigData)
 }
 
-func createSecret(name types.NamespacedName, key string, st corev1.SecretType, in io.Reader) (*corev1.Secret, error) {
-	data, err := ioutil.ReadAll(in)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read secret data: %v", err)
-	}
+func createSecret(name types.NamespacedName, key string, st corev1.SecretType, dockerConfigData []byte) (*corev1.Secret, error) {
+
 	secret := &corev1.Secret{
 		TypeMeta:   secretTypeMeta,
 		ObjectMeta: ObjectMeta(name),
 		Type:       st,
 		Data: map[string][]byte{
-			key: data,
+			key: dockerConfigData,
 		},
 	}
 	return secret, nil


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What does does this PR do / why we need it**:
- Introduces external registry support for build config
- Introduces delay to check for build pod completed status before triggering deploy
- Re-organizes common functions (createSecret, pipeStdOutput) to be accessible to both build config and kaniko



**How to test changes / Special notes to the reviewer**:
- create a new directory, and run ```odo create nodejs --starter=nodejs-starter```
- run ```odo url create```
- replace created devfile with the following sample
```
schemaVersion: 2.1.0
metadata:
  name: nodejs
  version: 1.0.0
  alpha.deployment-manifest: "https://raw.githubusercontent.com/groeges/devfile-registry/master/devfiles/nodejs/deploy_deployment.yaml"
projects:
  - name: nodejs-starter
    git:
      location: "https://github.com/odo-devfiles/nodejs-ex.git"
components:
  - container:
      name: runtime
      image: registry.access.redhat.com/ubi8/nodejs-12:1-36
      memoryLimit: 1024Mi
      mountSources: true
      endpoints:
        - name: http-3000
          targetPort: 3000
          configuration:
            protocol: tcp
            scheme: http
            type: terminal

  - dockerfile:
      name: dockerfile-build
      source: 
         sourceDir: "src"
         location: "https://github.com/ranakan19/golang-ex.git"
      dockerfileLocation: "https://raw.githubusercontent.com/jaideepr97/OpenShift-guides/master/Dockerfile"
      destination:
      Rootless: true 
    
commands:
  - exec:
      id: install
      component: runtime
      commandLine: npm install
      workingDir: /project
      group:
        kind: build
        isDefault: true
  - exec:
      id: run
      component: runtime
      commandLine: npm start
      workingDir: /project
      group:
        kind: run
        isDefault: true
  - exec:
      id: debug
      component: runtime
      commandLine: npm run debug
      workingDir: /project
      group:
        kind: debug
        isDefault: true
  - exec:
      id: test
      component: runtime
      commandLine: npm test
      workingDir: /project
      group:
        kind: test
        isDefault: true
```
- run ```odo deploy --tag=<imageTag> --dockerconfigjson=<path/to/config.json>```