### PR TITLE
Ignore status field of sealed secrets

### DIFF
--- a/pkg/pipelines/argocd/argocd.go
+++ b/pkg/pipelines/argocd/argocd.go
@@ -35,6 +35,7 @@ var (
 		{Group: "triggers.tekton.dev", Kind: "TriggerTemplate", JSONPointers: []string{"/status"}},
 		{Group: "triggers.tekton.dev", Kind: "TriggerBinding", JSONPointers: []string{"/status"}},
 		{Group: "route.openshift.io", Kind: "Route", JSONPointers: []string{"/spec/host"}},
+		{Group: "bitnami.com", Kind: "SealedSecret", JSONPointers: []string{"/status"}},
 	}
 
 	resourceExclusions = excludeResources{


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What does this PR do / why we need it**:

ArgoCD fails to sync the status field of sealed secrets in version 12.x. This PR will update the generated ArgoApps to ignore sealed secrets status

**Have you updated the necessary documentation?**

See https://github.com/rhd-gitops-example/docs

[ ] Updated

**Which issue(s) this PR fixes**:

Fixes https://issues.redhat.com/browse/GITOPS-254?

**How to test changes / Special notes to the reviewer**:
